### PR TITLE
qm: smoke v2 — density fitting, GPU warmup, cuTENSOR, bigger clusters

### DIFF
--- a/.claude/learnings/INDEX.md
+++ b/.claude/learnings/INDEX.md
@@ -1,3 +1,4 @@
 # Learnings Index
 
 - [gotchas.md](gotchas.md) — Petra decks need `[simulation]` even for validation; pyscf thermo auto-applies rotational symmetry numbers (R·ln σ entropy trap); petra's truncated gas constant vs CODATA (send barriers over the bridge, never rates)
+- [performance.md](performance.md) — first 4090-vs-CPU DFT timings: small jobs favor CPU; GPU wins need density fitting + warmup + cuTENSOR + ~100 atoms

--- a/.claude/learnings/performance.md
+++ b/.claude/learnings/performance.md
@@ -6,7 +6,7 @@ CPU E/grad/Hess = 22.4/7.1/316.5 s; GPU = 54.3/14.0/197.6 s (0.41×/0.51×/1.60�
 energies matched to 8 decimals. Three artifacts depressed the GPU numbers:
 (1) one-time CUDA/JIT warmup landed inside the first timed SCF, (2) no RI —
 GPU4PySCF's published wins assume density fitting, (3) cuTENSOR missing, so
-gpu4pyscf warned and fell back to cupy contractions. smoke v2 fixes all
+gpu4pyscf warned and fell back to CuPy contractions. smoke v2 fixes all
 three (warmup pass, DF default, cutensor-cu12 in the [gpu] extra) and adds
 --waters up to 24 to probe the 100+-atom regime; expect the survey's 2–5×
 (SCF/grad) and 5–10× (Hessian) only there. Small jobs should just run CPU.

--- a/.claude/learnings/performance.md
+++ b/.claude/learnings/performance.md
@@ -1,0 +1,12 @@
+# Performance
+
+### RTX 4090 vs 16C CPU, B3LYP/def2-TZVP, first real numbers (2026-08-18)
+Si(OH)4·2H2O (15 atoms), no density fitting, cold GPU, quarry phase0_smoke:
+CPU E/grad/Hess = 22.4/7.1/316.5 s; GPU = 54.3/14.0/197.6 s (0.41×/0.51×/1.60×);
+energies matched to 8 decimals. Three artifacts depressed the GPU numbers:
+(1) one-time CUDA/JIT warmup landed inside the first timed SCF, (2) no RI —
+GPU4PySCF's published wins assume density fitting, (3) cuTENSOR missing, so
+gpu4pyscf warned and fell back to cupy contractions. smoke v2 fixes all
+three (warmup pass, DF default, cutensor-cu12 in the [gpu] extra) and adds
+--waters up to 24 to probe the 100+-atom regime; expect the survey's 2–5×
+(SCF/grad) and 5–10× (Hessian) only there. Small jobs should just run CPU.

--- a/qm/README.md
+++ b/qm/README.md
@@ -39,9 +39,18 @@ On the workstation (RTX 4090), add the GPU extra and run the smoke test:
 
 ```bash
 uv sync --extra dev --extra gpu
-uv run python scripts/phase0_smoke.py          # full timing table
-uv run python scripts/phase0_smoke.py --quick  # seconds-long sanity check
+uv run python scripts/phase0_smoke.py            # full timing table (DF on)
+uv run python scripts/phase0_smoke.py --quick    # seconds-long sanity check
+uv run python scripts/phase0_smoke.py --waters 24  # ~100-atom-regime probe
 ```
+
+First measured table (2026-08-18, 15 atoms, **no** density fitting, cold
+GPU): CPU/GPU energies bitwise-matched; Hessian 1.6× GPU, SCF/gradient
+*slower* on GPU. That is the survey's predicted small-molecule worst case
+plus untimed-warmup and missing-cuTENSOR artifacts — the defaults now warm
+up the GPU, enable density fitting (the production path), and pull in
+cuTENSOR, and bigger `--waters` probes the regime where the survey's
+2–5×/5–10× claims live (details in `.claude/learnings/performance.md`).
 
 ### Not managed by uv (install separately, never commit)
 

--- a/qm/pyproject.toml
+++ b/qm/pyproject.toml
@@ -20,6 +20,9 @@ dependencies = [
 gpu = [
     "gpu4pyscf-cuda12x",
     "nvidia-cuest-cu12",
+    # Without cuTENSOR, gpu4pyscf falls back to cupy for tensor
+    # contractions (it warns at import) and leaves speed on the table.
+    "cutensor-cu12",
 ]
 dev = [
     "pytest>=8.0",

--- a/qm/quarry/clusters.py
+++ b/qm/quarry/clusters.py
@@ -171,31 +171,57 @@ def silicic_acid() -> Cluster:
     )
 
 
+def _shell_directions(n: int) -> list[np.ndarray]:
+    """n roughly-uniform unit vectors (golden-spiral points on a sphere)."""
+    golden = math.pi * (3.0 - math.sqrt(5.0))
+    dirs = []
+    for k in range(n):
+        z = 1.0 - 2.0 * (k + 0.5) / n
+        r = math.sqrt(max(0.0, 1.0 - z * z))
+        phi = golden * k
+        dirs.append(np.array([r * math.cos(phi), r * math.sin(phi), z]))
+    return dirs
+
+
+MAX_HYDRATE_WATERS = 24
+
+
+def _water_at(direction: np.ndarray, radius: float) -> list[np.ndarray]:
+    """[O, H, H] for a water at ``radius`` along ``direction``, H2 pointing
+    outward (dipole bisector along the shell normal) so shell waters never
+    reach back toward the core."""
+    d = _unit(direction)
+    ref = np.array([1.0, 0.0, 0.0])
+    if abs(np.dot(ref, d)) > 0.9:
+        ref = np.array([0.0, 1.0, 0.0])
+    e1 = _unit(np.cross(d, ref))
+    half = math.radians(104.5 / 2.0)
+    o = radius * d
+    h1 = o + R_O_H * (math.cos(half) * d + math.sin(half) * e1)
+    h2 = o + R_O_H * (math.cos(half) * d - math.sin(half) * e1)
+    return [o, h1, h2]
+
+
 def silicic_acid_hydrate(n_water: int) -> Cluster:
     """Si(OH)4 · n H2O — the Phase 0 smoke-test series (SURVEY.md §9).
 
-    Waters are placed on a loose shell around the cluster; only the
-    topology matters (the smoke test measures E+grad+Hessian cost, and
-    real work pre-optimizes).
+    Waters are placed on a loose golden-spiral shell around the cluster;
+    only the topology matters (the smoke test measures E+grad+Hessian
+    cost, and real work pre-optimizes). Larger n exists purely to push
+    the benchmark toward the 100+-atom regime where the GPU pays off.
     """
-    if not 0 <= n_water <= 6:
-        raise ValueError("n_water must be in 0..6")
+    if not 0 <= n_water <= MAX_HYDRATE_WATERS:
+        raise ValueError(f"n_water must be in 0..{MAX_HYDRATE_WATERS}")
     base = silicic_acid()
     symbols = list(base.symbols)
     coords = list(base.coords)
-    w = water()
-    shell_dirs = [
-        (1, 0, 0),
-        (-1, 0, 0),
-        (0, 1, 0),
-        (0, -1, 0),
-        (0, 0, 1),
-        (0, 0, -1),
-    ]
-    for k in range(n_water):
-        offset = 3.4 * _unit(np.array(shell_dirs[k], dtype=float))
-        symbols += w.symbols
-        coords += list(w.coords + offset)
+    # Second shell sits further out so waters never collide.
+    for d in _shell_directions(min(n_water, 12)):
+        symbols += ["O", "H", "H"]
+        coords += _water_at(d, 3.4)
+    for d in _shell_directions(max(0, n_water - 12)):
+        symbols += ["O", "H", "H"]
+        coords += _water_at(d, 6.2)
     return Cluster(
         name=f"silicic-acid-{n_water}w",
         symbols=symbols,

--- a/qm/quarry/pipeline.py
+++ b/qm/quarry/pipeline.py
@@ -38,6 +38,7 @@ class DftSettings:
     solvent: str | None = None
     dispersion: str | None = None  # e.g. "d3bj", "d4" (needs pyscf[dispersion])
     grid_level: int | None = None
+    density_fit: bool = False  # RI-JK; the production default (SURVEY §2.2, §3.2)
     use_gpu: bool = False
 
 
@@ -67,6 +68,8 @@ def _make_scf(mol: Any, settings: DftSettings) -> Any:
             mf.grids.level = settings.grid_level
     if settings.dispersion is not None:
         mf.disp = settings.dispersion
+    if settings.density_fit:
+        mf = mf.density_fit()
     if settings.solvent is not None:
         mf = mf.SMD() if settings.solvent.lower() == "smd" else mf.PCM()
     if settings.use_gpu:

--- a/qm/quarry/pipeline.py
+++ b/qm/quarry/pipeline.py
@@ -38,7 +38,10 @@ class DftSettings:
     solvent: str | None = None
     dispersion: str | None = None  # e.g. "d3bj", "d4" (needs pyscf[dispersion])
     grid_level: int | None = None
-    density_fit: bool = False  # RI-JK; the production default (SURVEY §2.2, §3.2)
+    # RI-JK. Off here so cheap tests and comparisons are explicit;
+    # production call sites and the smoke benchmark turn it on
+    # (SURVEY §2.2, §3.2).
+    density_fit: bool = False
     use_gpu: bool = False
 
 

--- a/qm/scripts/phase0_smoke.py
+++ b/qm/scripts/phase0_smoke.py
@@ -3,9 +3,9 @@
 
 Run on the workstation (SURVEY.md §9 Phase 0):
 
-    uv run python scripts/phase0_smoke.py            # full table
-    uv run python scripts/phase0_smoke.py --quick    # seconds-long sanity
-    uv run python scripts/phase0_smoke.py --waters 2 # bigger cluster
+    uv run python scripts/phase0_smoke.py             # full table (DF on)
+    uv run python scripts/phase0_smoke.py --quick     # seconds-long sanity
+    uv run python scripts/phase0_smoke.py --waters 24 # ~100-atom regime
 
 Prints a paste-back-able report: environment, library versions, GPU
 detection (gpu4pyscf + cuEST), then B3LYP/def2-TZVP energy, gradient,
@@ -65,6 +65,19 @@ def detect_gpu() -> tuple[bool, list[str]]:
         notes.append("nvidia-cuest present (INT8 FP64-emulation path available)")
     except ImportError:
         notes.append("nvidia-cuest not installed (FP64-native path only)")
+    try:
+        from gpu4pyscf.lib import cutensor as g4p_cutensor
+
+        engine = getattr(g4p_cutensor, "contract_engine", None)
+        if engine is None or "cutensor" in str(engine).lower():
+            notes.append("cuTENSOR contraction engine active")
+        else:
+            notes.append(
+                f"contraction engine = {engine} — install cuTENSOR "
+                "(`uv sync --extra gpu`) for faster contractions"
+            )
+    except ImportError:
+        pass
     return len(notes) > 0 and n > 0, notes
 
 
@@ -75,6 +88,21 @@ class Timing:
     gradient_s: float | None = None
     hessian_s: float | None = None
     e_tot: float | None = None
+
+
+def warm_up_gpu() -> None:
+    """Compile CUDA kernels / init cuBLAS on a throwaway job.
+
+    Without this the first timed GPU SCF absorbs tens of seconds of
+    one-time setup and the table reads as a slowdown (measured 2026-08-18
+    on the 4090: 54 s "energy" for a 15-atom job that reruns far faster).
+    """
+    mf = _make_scf(
+        build_mol(water(), DftSettings(xc="b3lyp", basis="def2-svp", use_gpu=True)),
+        DftSettings(xc="b3lyp", basis="def2-svp", use_gpu=True),
+    )
+    mf.kernel()
+    mf.nuc_grad_method().kernel()
 
 
 def time_engine(cluster, settings: DftSettings, *, hessian: bool) -> Timing:
@@ -106,10 +134,17 @@ def main() -> int:
     ap.add_argument(
         "--waters",
         type=int,
-        default=2,
-        help="n in Si(OH)4·nH2O for the timing run (default 2)",
+        default=6,
+        help="n in Si(OH)4·nH2O for the timing run (default 6; up to 24 "
+        "to approach the 100+-atom regime where the GPU pays off)",
     )
     ap.add_argument("--skip-hessian", action="store_true")
+    ap.add_argument(
+        "--no-df",
+        action="store_true",
+        help="disable density fitting (production runs use RI, so the "
+        "default table measures the DF path)",
+    )
     args = ap.parse_args()
 
     print("=" * 72)
@@ -134,17 +169,23 @@ def main() -> int:
         print(f"\nquick mode: {cluster.name} at HF/STO-3G")
     else:
         cluster = silicic_acid_hydrate(args.waters)
-        settings = DftSettings(xc="b3lyp", basis="def2-tzvp")
+        settings = DftSettings(
+            xc="b3lyp", basis="def2-tzvp", density_fit=not args.no_df
+        )
         hessian = not args.skip_hessian
+        df = "on" if settings.density_fit else "off"
         print(
             f"\ntarget: {cluster.name} ({len(cluster.symbols)} atoms), "
-            f"B3LYP/def2-TZVP, analytic Hessian={'yes' if hessian else 'no'}"
+            f"B3LYP/def2-TZVP, density fitting={df}, "
+            f"analytic Hessian={'yes' if hessian else 'no'}"
         )
 
     rows = [time_engine(cluster, settings, hessian=hessian)]
     if gpu_ok:
         from dataclasses import replace
 
+        print("warming up GPU (untimed kernel compile/init)...")
+        warm_up_gpu()
         rows.append(
             time_engine(cluster, replace(settings, use_gpu=True), hessian=hessian)
         )

--- a/qm/scripts/phase0_smoke.py
+++ b/qm/scripts/phase0_smoke.py
@@ -90,17 +90,19 @@ class Timing:
     e_tot: float | None = None
 
 
-def warm_up_gpu() -> None:
+def warm_up_gpu(settings: DftSettings) -> None:
     """Compile CUDA kernels / init cuBLAS on a throwaway job.
 
     Without this the first timed GPU SCF absorbs tens of seconds of
     one-time setup and the table reads as a slowdown (measured 2026-08-18
     on the 4090: 54 s "energy" for a 15-atom job that reruns far faster).
+    Runs on a bare water molecule but with the caller's method settings
+    so the same code paths (DF, functional, basis) get initialized.
     """
-    mf = _make_scf(
-        build_mol(water(), DftSettings(xc="b3lyp", basis="def2-svp", use_gpu=True)),
-        DftSettings(xc="b3lyp", basis="def2-svp", use_gpu=True),
-    )
+    from dataclasses import replace
+
+    warm = replace(settings, use_gpu=True)
+    mf = _make_scf(build_mol(water(), warm), warm)
     mf.kernel()
     mf.nuc_grad_method().kernel()
 
@@ -185,7 +187,7 @@ def main() -> int:
         from dataclasses import replace
 
         print("warming up GPU (untimed kernel compile/init)...")
-        warm_up_gpu()
+        warm_up_gpu(settings)
         rows.append(
             time_engine(cluster, replace(settings, use_gpu=True), hessian=hessian)
         )

--- a/qm/tests/test_clusters.py
+++ b/qm/tests/test_clusters.py
@@ -68,6 +68,8 @@ class TestBasics:
             assert len(c.symbols) == 9 + 3 * n
         with pytest.raises(ValueError):
             silicic_acid_hydrate(25)
+        with pytest.raises(ValueError):
+            silicic_acid_hydrate(-1)
 
     def test_hydrate_shells_never_collide(self):
         # Both shells populated at the maximum: waters must not overlap

--- a/qm/tests/test_clusters.py
+++ b/qm/tests/test_clusters.py
@@ -63,11 +63,17 @@ class TestBasics:
             assert _min_interatomic(c) > 0.85, c.name  # > shortest real bond
 
     def test_hydrate_series(self):
-        for n in (0, 1, 3, 6):
+        for n in (0, 1, 3, 6, 12, 24):
             c = silicic_acid_hydrate(n)
             assert len(c.symbols) == 9 + 3 * n
         with pytest.raises(ValueError):
-            silicic_acid_hydrate(7)
+            silicic_acid_hydrate(25)
+
+    def test_hydrate_shells_never_collide(self):
+        # Both shells populated at the maximum: waters must not overlap
+        # each other or the core.
+        c = silicic_acid_hydrate(24)
+        assert _min_interatomic(c) > 0.85
 
 
 class TestClusterContract:

--- a/qm/tests/test_pipeline.py
+++ b/qm/tests/test_pipeline.py
@@ -51,6 +51,15 @@ class TestElectronicStructure:
         assert mol.charge == 1
         assert mol.spin == 0
 
+    def test_density_fit_energy_close_to_exact(self):
+        from dataclasses import replace
+
+        e_exact = energy(water(), CHEAP)
+        e_df = energy(water(), replace(CHEAP, density_fit=True))
+        # RI error is well under 0.1 mHa/atom for sane aux bases.
+        assert e_df == pytest.approx(e_exact, abs=1e-3)
+        assert e_df != e_exact  # DF path actually taken
+
 
 class TestOptimization:
     def test_energy_decreases(self, opt_water):

--- a/qm/uv.lock
+++ b/qm/uv.lock
@@ -127,6 +127,16 @@ wheels = [
 ]
 
 [[package]]
+name = "cutensor-cu12"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/4f/7744b62f5d0c3ec0e4f1442ecd119343462d6f3a0d025508ace4f319d32a/cutensor_cu12-2.7.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:4518081e13a22c6fe1d7941ee7b0358f4ad71a1484e2a92563f0d1336476f939", size = 332968151 },
+    { url = "https://files.pythonhosted.org/packages/30/0b/c9a0d71cc847c7b90d21ae1062737dbc16104fc2c2219b51ec64752017c4/cutensor_cu12-2.7.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:ddedf0d94555c457c6c282dd7369c10fd10db22029f3731f1ed9420600188e6d", size = 332959918 },
+    { url = "https://files.pythonhosted.org/packages/30/bc/18bd0789acfb9d746b4542c9a794efe5debb21bf7114fb39f16662805c46/cutensor_cu12-2.7.0-py3-none-win_amd64.whl", hash = "sha256:6b5df750a43218a395b0ddc2607623c07f610a10ff2e5a071273d93e568010f0", size = 316268223 },
+]
+
+[[package]]
 name = "cycler"
 version = "0.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -845,6 +855,7 @@ dev = [
     { name = "ruff" },
 ]
 gpu = [
+    { name = "cutensor-cu12" },
     { name = "gpu4pyscf-cuda12x" },
     { name = "nvidia-cuest-cu12" },
 ]
@@ -852,6 +863,7 @@ gpu = [
 [package.metadata]
 requires-dist = [
     { name = "ase", specifier = ">=3.23" },
+    { name = "cutensor-cu12", marker = "extra == 'gpu'" },
     { name = "geometric", specifier = ">=1.0" },
     { name = "goodvibes", specifier = ">=3.2" },
     { name = "gpu4pyscf-cuda12x", marker = "extra == 'gpu'" },


### PR DESCRIPTION
## Summary
The first 4090 smoke run (15 atoms, B3LYP/def2-TZVP, no DF, cold GPU) measured **0.41×/0.51×/1.60×** GPU vs CPU for energy/gradient/Hessian with bitwise-identical energies. That's the survey's predicted small-molecule worst case compounded by three measurement artifacts; this PR fixes all three so the smoke table measures what SURVEY.md §3.2 actually claims:

- **GPU warmup pass** excluded from timings (the first GPU SCF was absorbing kernel-compile/cuBLAS init — tens of seconds on a 22 s job)
- **Density fitting on by default** (`--no-df` to opt out); `DftSettings` grows a `density_fit` flag. GPU4PySCF's published speedups assume RI, and production runs will use it
- **cuTENSOR** added to the `[gpu]` extra — gpu4pyscf was warning and falling back to cupy contractions; the script now reports the active contraction engine
- `silicic_acid_hydrate` extended to **24 waters (81 atoms)** on golden-spiral shells with outward-pointing hydrogens (no shell collisions); `--waters` default raised to 6

The measured table + interpretation live in `.claude/learnings/performance.md`; README documents the small-job-runs-CPU guidance.

## Test plan
- 66 tests green (65 fast + petra round-trip): new gates for DF accuracy vs exact integrals (≤1 mHa on water, and asserts the DF path is actually taken), hydrate series to n=24, min-interatomic-distance collision check at full shell occupancy
- ruff check + format clean
- `phase0_smoke.py --quick` runs in-session (CPU container)
- The real validation is the re-run on the workstation: `uv sync --extra dev --extra gpu && uv run python scripts/phase0_smoke.py` (then `--waters 24` for the large-regime probe)

## Breaking changes
None. `silicic_acid_hydrate` accepts a wider range; smoke-script defaults changed (DF on, 6 waters) — flags restore old behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Improve quantum-mechanics smoke benchmarks to measure representative GPU performance across density-fitted, warmed-up, and larger molecular workloads.

New Features:
- Add density-fitting support to DFT settings and enable it by default in the smoke benchmark, with an opt-out flag.
- Add GPU warmup and contraction-engine reporting to produce more representative GPU timings.
- Extend silicic acid hydrate benchmarks to 24 waters using collision-resistant shell placement.

Bug Fixes:
- Correct GPU benchmark measurements by excluding one-time CUDA initialization and kernel compilation from timed runs.
- Ensure GPU benchmarks use the cuTENSOR dependency instead of silently falling back to slower contractions.

Enhancements:
- Document benchmark performance findings and guidance for choosing CPU versus GPU execution.

Build:
- Add cuTENSOR to the GPU dependency extra.

Documentation:
- Update smoke-test usage and document the small-job CPU guidance and larger-cluster GPU benchmark regime.

Tests:
- Add coverage for density-fitting accuracy and verify that the DF path is exercised.
- Expand hydrate cluster coverage through 24 waters and validate maximum-shell atom separation.