### PR TITLE
qm: fix geomeTRIC constraint plumbing (file path, not inline text)

### DIFF
--- a/qm/quarry/pipeline.py
+++ b/qm/quarry/pipeline.py
@@ -13,6 +13,9 @@ default test gate exercises each rung on H2O/Si(OH)4.
 
 from __future__ import annotations
 
+import os
+import tempfile
+from contextlib import contextmanager
 from dataclasses import dataclass, replace
 from typing import Any
 
@@ -101,6 +104,20 @@ def gradient(cluster: Cluster, settings: DftSettings) -> np.ndarray:
     return np.asarray(mf.nuc_grad_method().kernel())
 
 
+@contextmanager
+def constraints_file(text: str):
+    """geomeTRIC takes constraints as a *file path*, not inline text
+    (passing text raises FileNotFoundError on the constraint string —
+    found live in the phase-1 scan). Yields a temp-file path."""
+    fd, path = tempfile.mkstemp(suffix=".constraints", text=True)
+    try:
+        with os.fdopen(fd, "w") as fh:
+            fh.write(text)
+        yield path
+    finally:
+        os.unlink(path)
+
+
 def optimize(
     cluster: Cluster, settings: DftSettings, *, max_steps: int = 100
 ) -> Cluster:
@@ -108,13 +125,14 @@ def optimize(
     from pyscf.geomopt.geometric_solver import optimize as geometric_optimize
 
     mf = _make_scf(build_mol(cluster, settings), settings)
-    params = {}
     if cluster.frozen_indices:
         # geomeTRIC constraint block: freeze xyz of the peripheral atoms
         # (the lattice-resistance contract, SURVEY.md §6.2).
         atoms = ",".join(str(i + 1) for i in sorted(cluster.frozen_indices))
-        params["constraints"] = f"$freeze\nxyz {atoms}\n"
-    mol_opt = geometric_optimize(mf, maxsteps=max_steps, **params)
+        with constraints_file(f"$freeze\nxyz {atoms}\n") as path:
+            mol_opt = geometric_optimize(mf, maxsteps=max_steps, constraints=path)
+    else:
+        mol_opt = geometric_optimize(mf, maxsteps=max_steps)
     return replace(
         cluster,
         symbols=[mol_opt.atom_symbol(i) for i in range(mol_opt.natm)],

--- a/qm/quarry/ts.py
+++ b/qm/quarry/ts.py
@@ -160,6 +160,8 @@ def constrained_scan(
     """
     from pyscf.geomopt.geometric_solver import optimize as geometric_optimize
 
+    from quarry.pipeline import constraints_file
+
     results: list[tuple[float, float, Cluster]] = []
     current = cluster
     for r in distances_a:
@@ -168,7 +170,8 @@ def constrained_scan(
             frozen = ",".join(str(k + 1) for k in sorted(current.frozen_indices))
             constraint += f"$freeze\nxyz {frozen}\n"
         mf = _make_scf(build_mol(current, settings), settings)
-        mol_opt = geometric_optimize(mf, maxsteps=max_steps, constraints=constraint)
+        with constraints_file(constraint) as path:
+            mol_opt = geometric_optimize(mf, maxsteps=max_steps, constraints=path)
         coords = mol_opt.atom_coords() * BOHR_TO_ANGSTROM
         current = replace(current, coords=coords, name=f"{cluster.name}-r{r:.2f}")
         mf2 = _make_scf(build_mol(current, settings), settings)

--- a/qm/tests/test_ts.py
+++ b/qm/tests/test_ts.py
@@ -112,6 +112,34 @@ class TestSaddleSearch:
         assert abs(ch_back - ch_fwd) > 0.3
 
 
+class TestConstraints:
+    """These run real geomeTRIC constraint plumbing — the inline-text
+    regression (FileNotFoundError on the constraint string) died here."""
+
+    def test_constrained_scan_holds_distance_and_raises_energy(self):
+        from quarry.ts import constrained_scan, scan_maximum
+
+        w = optimize(water(), CHEAP)
+        scan = constrained_scan(w, CHEAP, atom_i=0, atom_j=1, distances_a=[1.10, 1.30])
+        for r_target, _e, cl in scan:
+            r_actual = np.linalg.norm(cl.coords[0] - cl.coords[1])
+            assert r_actual == pytest.approx(r_target, abs=0.01)
+        # Stretching an O-H bond off equilibrium must cost energy.
+        assert scan[1][1] > scan[0][1]
+        assert scan_maximum(scan).name.endswith("r1.30")
+
+    def test_optimize_respects_frozen_atoms(self):
+        from dataclasses import replace
+
+        w = replace(water(), frozen_indices=[0, 1])
+        opt = optimize(w, CHEAP)
+        # Frozen atoms stay put to numerical drift (~1e-5 A observed).
+        assert np.allclose(opt.coords[0], w.coords[0], atol=1e-4)
+        assert np.allclose(opt.coords[1], w.coords[1], atol=1e-4)
+        # The free H must have moved off the deliberately-bad guess.
+        assert not np.allclose(opt.coords[2], w.coords[2], atol=1e-3)
+
+
 class TestVerifyTs:
     def test_minimum_rejected_as_ts(self):
         w = optimize(water(), CHEAP)


### PR DESCRIPTION
## Summary
The first live phase-1 campaign died in the relaxed scan: geomeTRIC's `constraints` argument is a **file path**, and quarry was passing the constraint text itself (`FileNotFoundError: '$set\ndistance 2 16 2.8'`). The frozen-atom path in `optimize()` had the same latent bug, never yet exercised.

- New `constraints_file()` context manager (pipeline.py) writes the constraint block to a temp file and cleans up; both `constrained_scan` and frozen-atom `optimize` now go through it
- Regression gates that would have caught this: a real two-point O–H constrained scan (held distance verified to 0.01 Å, energy rises off equilibrium, `scan_maximum` picks the stretched point) and a frozen-atom optimization (frozen pair immobile to 1e-4 Å, free atom relaxes)

## Test plan
- 78 tests green including the two new constraint gates (they exercise actual geomeTRIC plumbing, not mocks); ruff clean
- Campaign resumes from stage-2 checkpoints once this merges

## Breaking changes
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix geomeTRIC constraint handling so constrained scans and frozen-atom optimizations run correctly.

Bug Fixes:
- Fix geomeTRIC constrained scans and frozen-atom optimizations by supplying constraints through temporary files as required by the optimizer.

Tests:
- Add integration regression tests covering constrained bond scans and frozen-atom optimization behavior.