### PR TITLE
qm: auto-extend relaxed scans to an interior maximum + escaped-saddle guard

### DIFF
--- a/.claude/learnings/INDEX.md
+++ b/.claude/learnings/INDEX.md
@@ -2,3 +2,4 @@
 
 - [gotchas.md](gotchas.md) — Petra decks need `[simulation]` even for validation; pyscf thermo auto-applies rotational symmetry numbers (R·ln σ entropy trap); petra's truncated gas constant vs CODATA (send barriers over the bridge, never rates)
 - [performance.md](performance.md) — first 4090-vs-CPU DFT timings: small jobs favor CPU; GPU wins need density fitting + warmup + cuTENSOR + ~100 atoms
+- [debugging.md](debugging.md) — trivial-saddle trap: verified ≠ right saddle; interior scan maximum required before Sella

--- a/.claude/learnings/debugging.md
+++ b/.claude/learnings/debugging.md
@@ -1,0 +1,11 @@
+# Debugging
+
+### Saddle searches slide to trivial saddles from uncrossed-ridge guesses (2026-08-18)
+First live hydrolysis TS hunt: the r(Si-Ow) scan ended (1.9 A) with energy
+still rising, its endpoint became the Sella guess, and the search relaxed
+back to a 208i cm^-1 water-wag saddle — mechanically valid (1 imaginary
+mode, IRC converges) but chemically wrong (dG‡ 2.5 vs ~120 kJ/mol lit.).
+Diagnosis signature: the saddle's driven coordinate far past the guess and
+both quick-IRC ends identical to the reactant complex. Fixes in quarry:
+scan_to_maximum (extend until interior max) + escaped-channel guard in
+the phase-1 driver. A verified saddle is not necessarily the right saddle.

--- a/qm/quarry/clusters.py
+++ b/qm/quarry/clusters.py
@@ -285,26 +285,68 @@ def merge(a: Cluster, b: Cluster, name: str | None = None) -> Cluster:
     )
 
 
-def hydrolysis_complex(
-    dimer: Cluster, attacker: Cluster, *, approach_a: float = 3.2
-) -> Cluster:
-    """Attacker positioned for backside attack on the dimer's Si.
+def _rotation_between(a: np.ndarray, b: np.ndarray) -> np.ndarray:
+    """Rotation matrix taking unit direction of ``a`` onto that of ``b``."""
+    a, b = _unit(a), _unit(b)
+    v = np.cross(a, b)
+    c = float(np.dot(a, b))
+    s = np.linalg.norm(v)
+    if s < 1e-12:
+        if c > 0.0:
+            return np.eye(3)
+        # Antiparallel: rotate pi about any axis perpendicular to a.
+        p = _unit(np.cross(a, [1.0, 0.0, 0.0] if abs(a[0]) < 0.9 else [0.0, 1.0, 0.0]))
+        return 2.0 * np.outer(p, p) - np.eye(3)
+    vx = np.array([[0, -v[2], v[1]], [v[2], 0, -v[0]], [-v[1], v[0], 0]])
+    return np.eye(3) + vx + vx @ vx * ((1.0 - c) / s**2)
 
-    Convention from ``_bridged_dimer``: atom 0 is the bridging O, atom 1
-    the Si under attack. The attacker's O (its atom 0) is placed at
-    ``approach_a`` from Si, on the far side from the bridging O — the
-    SN2-like approach of the silicate hydrolysis literature (SURVEY.md
-    §6.2, §7.1: pentacoordinate Si TS). The geometry is a starting
-    guess; the pipeline optimizes it.
+
+def hydrolysis_complex(
+    dimer: Cluster,
+    attacker: Cluster,
+    *,
+    approach_a: float = 3.2,
+    mode: str = "flank",
+) -> Cluster:
+    """Attacker positioned to attack the dimer's Si (atom 1; atom 0 is
+    the bridging O). The geometry is a starting guess; the pipeline
+    optimizes it.
+
+    ``mode="flank"`` (default): the 4-center X&L geometry — attacker O
+    ~80 deg off the Si->Obr axis (same side as the bridge) with its
+    first H aimed at the bridging O, so the concerted proton transfer
+    is geometrically available. ``mode="backside"``: SN2-like approach
+    opposite the bridge (proton transfer NOT reachable from here —
+    measured live: nearest water H sat 3.9 A from the bridging O and
+    driving it across never produced an interior maximum).
     """
     bridge, si = dimer.coords[0], dimer.coords[1]
-    direction = _unit(si - bridge)
-    target = si + approach_a * direction
-    shifted = attacker.coords - attacker.coords[0] + target
+    to_bridge = _unit(bridge - si)
+    if mode == "backside":
+        target = si + approach_a * -to_bridge
+        rotated = attacker.coords - attacker.coords[0]
+    elif mode == "flank":
+        ref = np.array([1.0, 0.0, 0.0])
+        if abs(np.dot(ref, to_bridge)) > 0.9:
+            ref = np.array([0.0, 1.0, 0.0])
+        perp = _unit(np.cross(np.cross(to_bridge, ref), to_bridge))
+        theta = math.radians(80.0)
+        target = si + approach_a * (
+            math.cos(theta) * to_bridge + math.sin(theta) * perp
+        )
+        shifted = attacker.coords - attacker.coords[0]
+        if len(attacker.symbols) > 1:
+            # Aim the first O-H bond at the bridging O.
+            rot = _rotation_between(shifted[1], bridge - target)
+            rotated = shifted @ rot.T
+        else:
+            rotated = shifted
+    else:
+        raise ValueError(f"unknown attack mode '{mode}'")
     moved = Cluster(
         name=attacker.name,
         symbols=list(attacker.symbols),
-        coords=shifted,
+        coords=rotated + target,
         charge=attacker.charge,
         spin=attacker.spin,
     )

--- a/qm/quarry/ts.py
+++ b/qm/quarry/ts.py
@@ -239,6 +239,64 @@ def scan_ts_guess(scan: list[tuple[float, float, Cluster]]) -> Cluster:
     return scan[idx][2]
 
 
+def neb_ts_guess(
+    reactant: Cluster,
+    product: Cluster,
+    settings: DftSettings,
+    *,
+    n_images: int = 7,
+    fmax_ev_a: float = 0.10,
+    max_steps: int = 150,
+) -> Cluster:
+    """Climbing-image NEB between two basins; returns the peak image.
+
+    The remedy for saddle searches that escape the reaction channel
+    (observed live: Sella walked a crest guess from r(Si-Ow)=1.90 back
+    out to 3.22 A): the band is pinned to both basins so it cannot
+    escape, and the climbing image rides the path to the col, where the
+    lowest curvature direction *is* the reaction mode. The peak image
+    is then a Sella start it can refine rather than flee.
+
+    ``fmax_ev_a`` is deliberately loose — this produces a guess, and
+    Sella does the tight convergence.
+    """
+    from ase import Atoms
+
+    try:
+        from ase.mep import NEB
+    except ImportError:  # older ASE layout
+        from ase.neb import NEB
+    from ase.optimize import FIRE
+
+    if reactant.charge != product.charge or reactant.spin != product.spin:
+        raise ValueError("reactant/product electronic states differ")
+    images = [Atoms(symbols=reactant.symbols, positions=reactant.coords)]
+    for _ in range(n_images - 2):
+        images.append(images[0].copy())
+    images.append(Atoms(symbols=product.symbols, positions=product.coords))
+    for image in images:
+        image.calc = make_ase_calculator(settings, reactant.charge, reactant.spin)
+        if reactant.frozen_indices:
+            from ase.constraints import FixAtoms
+
+            image.set_constraint(FixAtoms(indices=reactant.frozen_indices))
+    neb = NEB(images, climb=True)
+    neb.interpolate(method="idpp")
+    FIRE(neb).run(fmax=fmax_ev_a, steps=max_steps)
+    energies = [float(image.get_potential_energy()) for image in images]
+    peak = int(np.argmax(energies))
+    if peak in (0, len(images) - 1):
+        raise RuntimeError(
+            "NEB peak landed on an endpoint — the two basins do not "
+            "bracket a barrier at this method/geometry"
+        )
+    return replace(
+        reactant,
+        coords=images[peak].positions.copy(),
+        name=f"{reactant.name}-neb-peak",
+    )
+
+
 class ScanNoMaximumError(RuntimeError):
     """A scan hit its distance floor with the energy still rising.
 

--- a/qm/quarry/ts.py
+++ b/qm/quarry/ts.py
@@ -192,8 +192,33 @@ def scan_maximum(scan: list[tuple[float, float, Cluster]]) -> Cluster:
     return max(scan, key=lambda p: p[1])[2]
 
 
+# Peaks must clear both neighbors by this much (Hartree) to count —
+# well above converged-optimization noise, well below any real barrier.
+_PEAK_TOL_HARTREE = 5e-5
+
+
+def first_interior_maximum(
+    scan: list[tuple[float, float, Cluster]], *, tol: float = _PEAK_TOL_HARTREE
+) -> int | None:
+    """Index of the first interior local energy maximum, else None.
+
+    The *first* crest along the driven coordinate is the saddle guess
+    for this elementary step. The global maximum is the wrong criterion:
+    once the driven bond has actually formed, pushing further just
+    compresses it and the energy rises without bound, so the global max
+    lands on the compression endpoint (observed live: proton-transfer
+    crest at r(Obr-H)=1.96 A, then bond formation, then a monotonic
+    compression wall that out-climbed the crest).
+    """
+    energies = [e for _, e, _ in scan]
+    for i in range(1, len(energies) - 1):
+        if energies[i] > energies[i - 1] + tol and energies[i] > energies[i + 1] + tol:
+            return i
+    return None
+
+
 def has_interior_maximum(scan: list[tuple[float, float, Cluster]]) -> bool:
-    """True when the scan's energy maximum is not an endpoint.
+    """True when the scan contains a genuine interior crest.
 
     A maximum at the tight end means the ridge has not been crossed and
     the "TS guess" is just the last constrained point — a saddle search
@@ -203,11 +228,15 @@ def has_interior_maximum(scan: list[tuple[float, float, Cluster]]) -> bool:
     """
     if len(scan) < 3:
         return False
-    energies = [e for _, e, _ in scan]
-    e_max = max(energies)
-    # Strictly above both endpoints — a plateau shared with an endpoint
-    # does not count as a crossed ridge.
-    return energies[0] < e_max and energies[-1] < e_max
+    return first_interior_maximum(scan) is not None
+
+
+def scan_ts_guess(scan: list[tuple[float, float, Cluster]]) -> Cluster:
+    """The structure at the first interior crest — the Sella guess."""
+    idx = first_interior_maximum(scan)
+    if idx is None:
+        raise ValueError("scan has no interior energy maximum")
+    return scan[idx][2]
 
 
 class ScanNoMaximumError(RuntimeError):

--- a/qm/quarry/ts.py
+++ b/qm/quarry/ts.py
@@ -150,13 +150,16 @@ def constrained_scan(
     atom_i: int,
     atom_j: int,
     distances_a: list[float],
+    fixed_distances: list[tuple[int, int, float]] = (),
     max_steps: int = 150,
 ) -> list[tuple[float, float, Cluster]]:
     """Relaxed scan of one interatomic distance (TS-guess generator).
 
     Optimizes the cluster with r(i,j) frozen at each value; returns
     (distance, energy_hartree, relaxed_cluster) tuples in scan order.
-    The maximum-energy point is the natural Sella starting guess.
+    ``fixed_distances`` holds additional (i, j, r) pairs constrained at
+    every point — e.g. pinning the nucleophile in place while a proton
+    is driven. The maximum-energy point is the natural Sella guess.
     """
     from pyscf.geomopt.geometric_solver import optimize as geometric_optimize
 
@@ -166,6 +169,8 @@ def constrained_scan(
     current = cluster
     for r in distances_a:
         constraint = f"$set\ndistance {atom_i + 1} {atom_j + 1} {r:.4f}\n"
+        for fi, fj, fr in fixed_distances:
+            constraint += f"distance {fi + 1} {fj + 1} {fr:.4f}\n"
         if current.frozen_indices:
             frozen = ",".join(str(k + 1) for k in sorted(current.frozen_indices))
             constraint += f"$freeze\nxyz {frozen}\n"
@@ -205,6 +210,18 @@ def has_interior_maximum(scan: list[tuple[float, float, Cluster]]) -> bool:
     return energies[0] < e_max and energies[-1] < e_max
 
 
+class ScanNoMaximumError(RuntimeError):
+    """A scan hit its distance floor with the energy still rising.
+
+    Carries the completed scan so callers can pivot to a second driven
+    coordinate from the best structure already computed.
+    """
+
+    def __init__(self, message: str, scan: list[tuple[float, float, Cluster]]):
+        super().__init__(message)
+        self.scan = scan
+
+
 def scan_to_maximum(
     cluster: Cluster,
     settings: DftSettings,
@@ -212,14 +229,16 @@ def scan_to_maximum(
     atom_i: int,
     atom_j: int,
     distances_a: list[float],
+    fixed_distances: list[tuple[int, int, float]] = (),
     extend_step_a: float = 0.08,
     min_distance_a: float = 1.60,
     max_steps: int = 150,
     progress=None,
 ) -> list[tuple[float, float, Cluster]]:
     """Relaxed scan that keeps tightening r(i,j) until the maximum is
-    interior (or ``min_distance_a`` is hit — then a RuntimeError, since a
-    guess from an uncrossed ridge is worse than no guess).
+    interior (or ``min_distance_a`` is hit — then ``ScanNoMaximumError``
+    carrying the scan, since a guess from an uncrossed ridge is worse
+    than no guess).
 
     ``progress`` is an optional callable taking (r, energy) per point.
     """
@@ -229,6 +248,7 @@ def scan_to_maximum(
         atom_i=atom_i,
         atom_j=atom_j,
         distances_a=distances_a,
+        fixed_distances=fixed_distances,
         max_steps=max_steps,
     )
     if progress:
@@ -237,11 +257,12 @@ def scan_to_maximum(
     while not has_interior_maximum(scan):
         next_r = round(scan[-1][0] - extend_step_a, 3)
         if next_r < min_distance_a:
-            raise RuntimeError(
+            raise ScanNoMaximumError(
                 f"scan reached r={scan[-1][0]:.2f} A without an interior "
                 "energy maximum — the driven coordinate alone does not "
                 "cross the ridge; a different or combined reaction "
-                "coordinate is needed"
+                "coordinate is needed",
+                scan,
             )
         ext = constrained_scan(
             scan[-1][2],
@@ -249,6 +270,7 @@ def scan_to_maximum(
             atom_i=atom_i,
             atom_j=atom_j,
             distances_a=[next_r],
+            fixed_distances=fixed_distances,
             max_steps=max_steps,
         )
         if progress:

--- a/qm/quarry/ts.py
+++ b/qm/quarry/ts.py
@@ -185,3 +185,71 @@ def scan_maximum(scan: list[tuple[float, float, Cluster]]) -> Cluster:
     if not scan:
         raise ValueError("empty scan")
     return max(scan, key=lambda p: p[1])[2]
+
+
+def has_interior_maximum(scan: list[tuple[float, float, Cluster]]) -> bool:
+    """True when the scan's energy maximum is not an endpoint.
+
+    A maximum at the tight end means the ridge has not been crossed and
+    the "TS guess" is just the last constrained point — a saddle search
+    from it slides back into the reactant basin (observed live: Sella
+    relaxed a monotonic scan's endpoint into a 208i cm^-1 water-wag
+    saddle with a 2.5 kJ/mol "barrier"). Extend the scan instead.
+    """
+    if len(scan) < 3:
+        return False
+    energies = [e for _, e, _ in scan]
+    return 0 < energies.index(max(energies)) < len(energies) - 1
+
+
+def scan_to_maximum(
+    cluster: Cluster,
+    settings: DftSettings,
+    *,
+    atom_i: int,
+    atom_j: int,
+    distances_a: list[float],
+    extend_step_a: float = 0.08,
+    min_distance_a: float = 1.60,
+    max_steps: int = 150,
+    progress=None,
+) -> list[tuple[float, float, Cluster]]:
+    """Relaxed scan that keeps tightening r(i,j) until the maximum is
+    interior (or ``min_distance_a`` is hit — then a RuntimeError, since a
+    guess from an uncrossed ridge is worse than no guess).
+
+    ``progress`` is an optional callable taking (r, energy) per point.
+    """
+    scan = constrained_scan(
+        cluster,
+        settings,
+        atom_i=atom_i,
+        atom_j=atom_j,
+        distances_a=distances_a,
+        max_steps=max_steps,
+    )
+    if progress:
+        for r, e, _ in scan:
+            progress(r, e)
+    while not has_interior_maximum(scan):
+        next_r = round(scan[-1][0] - extend_step_a, 3)
+        if next_r < min_distance_a:
+            raise RuntimeError(
+                f"scan reached r={scan[-1][0]:.2f} A without an interior "
+                "energy maximum — the driven coordinate alone does not "
+                "cross the ridge; a different or combined reaction "
+                "coordinate is needed"
+            )
+        ext = constrained_scan(
+            scan[-1][2],
+            settings,
+            atom_i=atom_i,
+            atom_j=atom_j,
+            distances_a=[next_r],
+            max_steps=max_steps,
+        )
+        if progress:
+            for r, e, _ in ext:
+                progress(r, e)
+        scan.extend(ext)
+    return scan

--- a/qm/quarry/ts.py
+++ b/qm/quarry/ts.py
@@ -199,7 +199,10 @@ def has_interior_maximum(scan: list[tuple[float, float, Cluster]]) -> bool:
     if len(scan) < 3:
         return False
     energies = [e for _, e, _ in scan]
-    return 0 < energies.index(max(energies)) < len(energies) - 1
+    e_max = max(energies)
+    # Strictly above both endpoints — a plateau shared with an endpoint
+    # does not count as a crossed ridge.
+    return energies[0] < e_max and energies[-1] < e_max
 
 
 def scan_to_maximum(

--- a/qm/scripts/phase1_xiao_lasaga.py
+++ b/qm/scripts/phase1_xiao_lasaga.py
@@ -60,8 +60,8 @@ from quarry.ts import (  # noqa: E402
     ScanNoMaximumError,
     find_ts,
     quick_irc,
-    scan_maximum,
     scan_to_maximum,
+    scan_ts_guess,
 )
 
 REACTIONS = {
@@ -200,7 +200,7 @@ def main() -> int:
                 distances_a=[2.8, 2.6, 2.4, 2.2, 2.1, 2.0, 1.9],
                 progress=lambda r, e: log(f"  r={r:.2f} A  E={e:.6f} Ha"),
             )
-            ts_guess = scan_maximum(scan)
+            ts_guess = scan_ts_guess(scan)
         except ScanNoMaximumError as exc:
             log("  approach coordinate alone does not cross the ridge;")
             log("  stage 2b: pin r(Si-Ow)=1.90 A, drive H(water) -> O(bridge)")
@@ -226,7 +226,7 @@ def main() -> int:
                 min_distance_a=0.95,
                 progress=lambda r, e: log(f"  r(Obr-H)={r:.2f} A  E={e:.6f} Ha"),
             )
-            ts_guess = scan_maximum(pscan)
+            ts_guess = scan_ts_guess(pscan)
         save_xyz(ts_guess, ts_guess_path)
 
     # Stage 3 — saddle search.

--- a/qm/scripts/phase1_xiao_lasaga.py
+++ b/qm/scripts/phase1_xiao_lasaga.py
@@ -56,7 +56,13 @@ from quarry.pipeline import (  # noqa: E402
 )
 from quarry.rates import rate_from_thermo, thermo_from_frequencies  # noqa: E402
 from quarry.store import Store  # noqa: E402
-from quarry.ts import find_ts, quick_irc, scan_maximum, scan_to_maximum  # noqa: E402
+from quarry.ts import (  # noqa: E402
+    ScanNoMaximumError,
+    find_ts,
+    quick_irc,
+    scan_maximum,
+    scan_to_maximum,
+)
 
 REACTIONS = {
     "si-neutral": (disilicate, water),
@@ -66,6 +72,7 @@ REACTIONS = {
 }
 # Indices from the builders: 0 = bridging O, 1 = Si under attack;
 # the attacker's O is the first atom appended after the dimer.
+BR_INDEX = 0
 SI_INDEX = 1
 KCAL = 4.184
 
@@ -167,21 +174,52 @@ def main() -> int:
 
     # Stage 2 — relaxed scan pulling the attacker O onto Si, extended
     # until the energy maximum is interior (ridge actually crossed).
+    # The neutral 4-center mechanism needs a second driven coordinate:
+    # if approach alone never peaks (observed live: monotonic to 1.66 A,
+    # +115 kJ/mol), pin r(Si-Ow) and drive the water proton onto the
+    # bridging O — the concerted proton transfer of the X&L TS.
     log("stage 2: relaxed scan r(Si-Ow), auto-extending to interior maximum")
     ts_guess_path = run_dir / "ts_guess.xyz"
     if ts_guess_path.exists():
         ts_guess = load_xyz(ts_guess_path, complex_opt)
         log("  resume: ts_guess.xyz exists")
     else:
-        scan = scan_to_maximum(
-            complex_opt,
-            settings,
-            atom_i=SI_INDEX,
-            atom_j=ow_index,
-            distances_a=[2.8, 2.6, 2.4, 2.2, 2.1, 2.0, 1.9],
-            progress=lambda r, e: log(f"  r={r:.2f} A  E={e:.6f} Ha"),
-        )
-        ts_guess = scan_maximum(scan)
+        try:
+            scan = scan_to_maximum(
+                complex_opt,
+                settings,
+                atom_i=SI_INDEX,
+                atom_j=ow_index,
+                distances_a=[2.8, 2.6, 2.4, 2.2, 2.1, 2.0, 1.9],
+                progress=lambda r, e: log(f"  r={r:.2f} A  E={e:.6f} Ha"),
+            )
+            ts_guess = scan_maximum(scan)
+        except ScanNoMaximumError as exc:
+            log("  approach coordinate alone does not cross the ridge;")
+            log("  stage 2b: pin r(Si-Ow)=1.90 A, drive H(water) -> O(bridge)")
+            base = min(exc.scan, key=lambda p: abs(p[0] - 1.90))[2]
+            # The water H closest to the bridging O is the one to shuttle.
+            h_candidates = [ow_index + 1, ow_index + 2]
+            h_idx = min(
+                h_candidates,
+                key=lambda i: np.linalg.norm(base.coords[i] - base.coords[BR_INDEX]),
+            )
+            r0 = float(np.linalg.norm(base.coords[h_idx] - base.coords[BR_INDEX]))
+            log(f"  driving H{h_idx} from r(Obr-H)={r0:.2f} A inward")
+            first = max(1.05, round(r0 - 0.15, 2))
+            distances = [round(x, 2) for x in np.arange(first, 1.04, -0.15)]
+            pscan = scan_to_maximum(
+                base,
+                settings,
+                atom_i=BR_INDEX,
+                atom_j=h_idx,
+                distances_a=distances or [first],
+                fixed_distances=[(SI_INDEX, ow_index, 1.90)],
+                extend_step_a=0.06,
+                min_distance_a=0.95,
+                progress=lambda r, e: log(f"  r(Obr-H)={r:.2f} A  E={e:.6f} Ha"),
+            )
+            ts_guess = scan_maximum(pscan)
         save_xyz(ts_guess, ts_guess_path)
 
     # Stage 3 — saddle search.

--- a/qm/scripts/phase1_xiao_lasaga.py
+++ b/qm/scripts/phase1_xiao_lasaga.py
@@ -59,6 +59,8 @@ from quarry.store import Store  # noqa: E402
 from quarry.ts import (  # noqa: E402
     ScanNoMaximumError,
     find_ts,
+    first_interior_maximum,
+    neb_ts_guess,
     quick_irc,
     scan_to_maximum,
     scan_ts_guess,
@@ -226,7 +228,25 @@ def main() -> int:
                 min_distance_a=0.95,
                 progress=lambda r, e: log(f"  r(Obr-H)={r:.2f} A  E={e:.6f} Ha"),
             )
-            ts_guess = scan_ts_guess(pscan)
+            # A raw crest guess lets Sella escape the channel (measured:
+            # r(Si-Ow) 1.90 -> 3.22). Instead: relax the post-crest
+            # structure into the product basin, then CI-NEB from complex
+            # to product — the climbing image rides to the col.
+            crest_idx = first_interior_maximum(pscan)
+            if crest_idx is None:
+                log("  !! proton scan produced no crest either — aborting")
+                return 1
+            seed_idx = min(crest_idx + 1, len(pscan) - 1)
+            log("  stage 2c: relaxing post-crest structure into the product basin")
+            product = checkpointed(
+                run_dir / "product.xyz",
+                pscan[seed_idx][2],
+                lambda: optimize(pscan[seed_idx][2], settings),
+            )
+            r_prod = np.linalg.norm(product.coords[SI_INDEX] - product.coords[ow_index])
+            log(f"  product r(Si-Ow)={r_prod:.2f} A")
+            log("  stage 2d: CI-NEB complex -> product (7 images)")
+            ts_guess = neb_ts_guess(complex_opt, product, settings)
         save_xyz(ts_guess, ts_guess_path)
 
     # Stage 3 — saddle search.

--- a/qm/scripts/phase1_xiao_lasaga.py
+++ b/qm/scripts/phase1_xiao_lasaga.py
@@ -229,22 +229,55 @@ def main() -> int:
                 progress=lambda r, e: log(f"  r(Obr-H)={r:.2f} A  E={e:.6f} Ha"),
             )
             # A raw crest guess lets Sella escape the channel (measured:
-            # r(Si-Ow) 1.90 -> 3.22). Instead: relax the post-crest
-            # structure into the product basin, then CI-NEB from complex
-            # to product — the climbing image rides to the col.
+            # r(Si-Ow) 1.90 -> 3.22). And a bare free relax of the
+            # post-crest structure rolls BACK to reactants (measured:
+            # product r(Si-Ow)=3.16 — proton returned, water left):
+            # a single proton transfer with the bridge intact is not a
+            # minimum. Hydrolysis completes by Si-Obr cleavage, so build
+            # the product deliberately: hold the new bonds, break the
+            # bridge, then free-optimize into 2 Si(OH)4.
             crest_idx = first_interior_maximum(pscan)
             if crest_idx is None:
                 log("  !! proton scan produced no crest either — aborting")
                 return 1
             seed_idx = min(crest_idx + 1, len(pscan) - 1)
-            log("  stage 2c: relaxing post-crest structure into the product basin")
+
+            def build_product():
+                log("  stage 2c: breaking Si-Obr with the new bonds held")
+                from quarry.ts import constrained_scan
+
+                broken = constrained_scan(
+                    pscan[seed_idx][2],
+                    settings,
+                    atom_i=SI_INDEX,
+                    atom_j=BR_INDEX,
+                    distances_a=[1.85, 2.05, 2.30, 2.60],
+                    fixed_distances=[
+                        (SI_INDEX, ow_index, 1.70),
+                        (BR_INDEX, h_idx, 0.98),
+                    ],
+                )
+                for r, e, _ in broken:
+                    log(f"  r(Si-Obr)={r:.2f} A  E={e:.6f} Ha")
+                return optimize(broken[-1][2], settings)
+
             product = checkpointed(
-                run_dir / "product.xyz",
-                pscan[seed_idx][2],
-                lambda: optimize(pscan[seed_idx][2], settings),
+                run_dir / "product.xyz", pscan[seed_idx][2], build_product
             )
-            r_prod = np.linalg.norm(product.coords[SI_INDEX] - product.coords[ow_index])
-            log(f"  product r(Si-Ow)={r_prod:.2f} A")
+            r_prod_ow = float(
+                np.linalg.norm(product.coords[SI_INDEX] - product.coords[ow_index])
+            )
+            r_prod_br = float(
+                np.linalg.norm(product.coords[SI_INDEX] - product.coords[BR_INDEX])
+            )
+            log(f"  product r(Si-Ow)={r_prod_ow:.2f} A, r(Si-Obr)={r_prod_br:.2f} A")
+            if r_prod_ow > 1.9 or r_prod_br < 2.2:
+                log(
+                    "  !! product rolled back toward reactants "
+                    "(hydrolyzed minimum requires Si-Ow bonded, Si-Obr "
+                    "broken) — aborting; inspect product.xyz"
+                )
+                return 1
             log("  stage 2d: CI-NEB complex -> product (7 images)")
             ts_guess = neb_ts_guess(complex_opt, product, settings)
         save_xyz(ts_guess, ts_guess_path)
@@ -265,6 +298,18 @@ def main() -> int:
     )
     r_ts = float(np.linalg.norm(ts.coords[SI_INDEX] - ts.coords[ow_index]))
     log(f"  r(Si-Ow): guess {r_guess:.2f} A -> saddle {r_ts:.2f} A")
+    # The 4-center hydrolysis saddle is in-channel by construction:
+    # forming Si-Ow bond ~1.8-2.2 A. A saddle sitting outside bonding
+    # range is a complex-rearrangement saddle whatever its history
+    # (observed live: 45.7i at r(Si-Ow)=3.15 from a reactant-conformer
+    # NEB after the product basin escaped).
+    if r_ts > 2.6:
+        log(
+            f"  !! saddle at r(Si-Ow)={r_ts:.2f} A is outside the bonding "
+            "channel — not the hydrolysis TS. Aborting before "
+            "thermochemistry; inspect ts.xyz and product.xyz."
+        )
+        return 1
     if r_ts > r_guess + 0.5:
         log(
             "  !! saddle escaped the approach channel (r(Si-Ow) grew by "

--- a/qm/scripts/phase1_xiao_lasaga.py
+++ b/qm/scripts/phase1_xiao_lasaga.py
@@ -122,6 +122,13 @@ def main() -> int:
         default=16,
         help="OMP thread cap for CPU stages (default 16 — leave the box usable)",
     )
+    ap.add_argument(
+        "--approach",
+        choices=["flank", "backside"],
+        default="flank",
+        help="attack geometry: flank = X&L 4-center (proton can reach the "
+        "bridging O), backside = SN2-like (no concerted transfer)",
+    )
     ap.add_argument("--temperature", type=float, default=298.15)
     args = ap.parse_args()
 
@@ -134,7 +141,7 @@ def main() -> int:
         Path(__file__).resolve().parent.parent
         / "runs"
         / "phase1"
-        / (f"{args.reaction}-{args.xc}-{args.basis}")
+        / (f"{args.reaction}-{args.xc}-{args.basis}-{args.approach}")
     )
     run_dir.mkdir(parents=True, exist_ok=True)
     log(f"run dir: {run_dir}")
@@ -142,7 +149,7 @@ def main() -> int:
 
     dimer_factory, attacker_factory = REACTIONS[args.reaction]
     dimer, attacker = dimer_factory(), attacker_factory()
-    complex_guess = hydrolysis_complex(dimer, attacker)
+    complex_guess = hydrolysis_complex(dimer, attacker, mode=args.approach)
     ow_index = len(dimer.symbols)  # attacker O
 
     # Stage 0 — cheap, robust pre-optimization of the hand-built guess.

--- a/qm/scripts/phase1_xiao_lasaga.py
+++ b/qm/scripts/phase1_xiao_lasaga.py
@@ -56,7 +56,7 @@ from quarry.pipeline import (  # noqa: E402
 )
 from quarry.rates import rate_from_thermo, thermo_from_frequencies  # noqa: E402
 from quarry.store import Store  # noqa: E402
-from quarry.ts import constrained_scan, find_ts, quick_irc, scan_maximum  # noqa: E402
+from quarry.ts import find_ts, quick_irc, scan_maximum, scan_to_maximum  # noqa: E402
 
 REACTIONS = {
     "si-neutral": (disilicate, water),
@@ -165,22 +165,22 @@ def main() -> int:
         lambda: optimize(attacker, settings),
     )
 
-    # Stage 2 — relaxed scan pulling the attacker O onto Si.
-    log("stage 2: relaxed scan r(Si-Ow) 2.8 -> 1.9 A")
+    # Stage 2 — relaxed scan pulling the attacker O onto Si, extended
+    # until the energy maximum is interior (ridge actually crossed).
+    log("stage 2: relaxed scan r(Si-Ow), auto-extending to interior maximum")
     ts_guess_path = run_dir / "ts_guess.xyz"
     if ts_guess_path.exists():
         ts_guess = load_xyz(ts_guess_path, complex_opt)
         log("  resume: ts_guess.xyz exists")
     else:
-        scan = constrained_scan(
+        scan = scan_to_maximum(
             complex_opt,
             settings,
             atom_i=SI_INDEX,
             atom_j=ow_index,
             distances_a=[2.8, 2.6, 2.4, 2.2, 2.1, 2.0, 1.9],
+            progress=lambda r, e: log(f"  r={r:.2f} A  E={e:.6f} Ha"),
         )
-        for r, e, _ in scan:
-            log(f"  r={r:.2f} A  E={e:.6f} Ha")
         ts_guess = scan_maximum(scan)
         save_xyz(ts_guess, ts_guess_path)
 
@@ -191,6 +191,23 @@ def main() -> int:
         ts_guess,
         lambda: find_ts(ts_guess, settings, trajectory=str(run_dir / "sella.traj")),
     )
+
+    # Guard: a saddle that drifted back out of the approach channel is a
+    # trivial complex-rearrangement saddle, not the hydrolysis TS
+    # (observed live: 208i water wag at r(Si-Ow)=3.25 from a bad guess).
+    r_guess = float(
+        np.linalg.norm(ts_guess.coords[SI_INDEX] - ts_guess.coords[ow_index])
+    )
+    r_ts = float(np.linalg.norm(ts.coords[SI_INDEX] - ts.coords[ow_index]))
+    log(f"  r(Si-Ow): guess {r_guess:.2f} A -> saddle {r_ts:.2f} A")
+    if r_ts > r_guess + 0.5:
+        log(
+            "  !! saddle escaped the approach channel (r(Si-Ow) grew by "
+            f"{r_ts - r_guess:.2f} A) — this is not the hydrolysis TS. "
+            "Delete ts.xyz/ts_guess.xyz and rerun with a tighter scan, or "
+            "drive a combined coordinate. Aborting before thermochemistry."
+        )
+        return 1
 
     # Stage 4 — verify + quick IRC.
     log("stage 4: frequencies + quick-IRC")

--- a/qm/tests/test_ts.py
+++ b/qm/tests/test_ts.py
@@ -164,6 +164,32 @@ class TestScanExtension:
         ]
         assert not has_interior_maximum(plateau)
 
+    def test_first_crest_beats_compression_wall(self):
+        # The observed proton-transfer profile: crest, bond formation
+        # dip, then a monotonic compression wall that out-climbs the
+        # crest at the endpoint. The guess must be the first crest.
+        from quarry.ts import first_interior_maximum, scan_ts_guess
+
+        profile = [
+            (2.26, 0.001),
+            (1.96, 0.007),  # the real crest
+            (1.81, -0.001),  # proton snapped over
+            (1.21, 0.010),
+            (1.06, 0.015),  # compression wall, global max at endpoint
+        ]
+        scan = [self._fake_point(r, e) for r, e in profile]
+        assert first_interior_maximum(scan) == 1
+        assert scan_ts_guess(scan).name == "p-r1.96"
+
+    def test_scan_ts_guess_requires_interior_crest(self):
+        from quarry.ts import scan_ts_guess
+
+        rising = [
+            self._fake_point(r, e) for r, e in [(2.8, 0.0), (2.4, 1.0), (2.0, 2.0)]
+        ]
+        with pytest.raises(ValueError, match="no interior"):
+            scan_ts_guess(rising)
+
     def test_scan_extends_until_peak(self, monkeypatch):
         import quarry.ts as ts_mod
 

--- a/qm/tests/test_ts.py
+++ b/qm/tests/test_ts.py
@@ -158,6 +158,11 @@ class TestScanExtension:
         assert not has_interior_maximum(rising)
         assert has_interior_maximum(peaked)
         assert not has_interior_maximum(peaked[:2])  # too short to say
+        # A plateau shared with an endpoint is not a crossed ridge.
+        plateau = [
+            self._fake_point(r, e) for r, e in [(2.8, 0.0), (2.4, 2.0), (2.0, 2.0)]
+        ]
+        assert not has_interior_maximum(plateau)
 
     def test_scan_extends_until_peak(self, monkeypatch):
         import quarry.ts as ts_mod

--- a/qm/tests/test_ts.py
+++ b/qm/tests/test_ts.py
@@ -111,6 +111,18 @@ class TestSaddleSearch:
         ch_fwd = np.linalg.norm(fwd.coords[2] - fwd.coords[0])
         assert abs(ch_back - ch_fwd) > 0.3
 
+    def test_neb_peak_approximates_the_saddle(self, ts):
+        from quarry.ts import neb_ts_guess
+
+        back, fwd = quick_irc(ts, CHEAP)
+        guess = neb_ts_guess(back, fwd, CHEAP, n_images=5, max_steps=80)
+        e_guess = energy(guess, CHEAP)
+        e_ts = energy(ts, CHEAP)
+        # The climbing image should land near the true saddle energy,
+        # from above or below within the loose NEB convergence.
+        assert abs(e_guess - e_ts) < 0.02  # Hartree (~50 kJ/mol slack)
+        assert e_guess > energy(back, CHEAP)
+
 
 class TestConstraints:
     """These run real geomeTRIC constraint plumbing — the inline-text

--- a/qm/tests/test_ts.py
+++ b/qm/tests/test_ts.py
@@ -248,8 +248,8 @@ class TestComplexBuilders:
         assert m.frozen_indices == [1, len(a.symbols)]
         assert len(m.symbols) == len(a.symbols) + len(b.symbols)
 
-    def test_neutral_attack_complex(self):
-        c = hydrolysis_complex(disilicate(), water())
+    def test_backside_attack_complex(self):
+        c = hydrolysis_complex(disilicate(), water(), mode="backside")
         assert c.charge == 0
         assert len(c.symbols) == 15 + 3
         # Attacker O sits ~approach distance from the Si under attack,
@@ -257,6 +257,25 @@ class TestComplexBuilders:
         si, o_attack = c.coords[1], c.coords[15]
         assert np.linalg.norm(o_attack - si) == pytest.approx(3.2, abs=0.05)
         assert np.linalg.norm(o_attack - c.coords[0]) > np.linalg.norm(si - c.coords[0])
+
+    def test_flank_attack_complex_geometry(self):
+        c = hydrolysis_complex(disilicate(), water())  # flank is default
+        obr, si, ow = c.coords[0], c.coords[1], c.coords[15]
+        assert np.linalg.norm(ow - si) == pytest.approx(3.2, abs=0.05)
+        # Ow-Si-Obr angle near the 4-center arrangement (80 deg built in).
+        v1, v2 = ow - si, obr - si
+        cos = np.dot(v1, v2) / (np.linalg.norm(v1) * np.linalg.norm(v2))
+        assert 60.0 < np.degrees(np.arccos(cos)) < 100.0
+        # The aimed water H must actually be able to reach the bridging O
+        # (backside had it at 3.9 A — the measured failure).
+        h_to_obr = min(
+            np.linalg.norm(c.coords[16] - obr), np.linalg.norm(c.coords[17] - obr)
+        )
+        assert h_to_obr < 2.6
+
+    def test_unknown_mode_rejected(self):
+        with pytest.raises(ValueError, match="unknown attack mode"):
+            hydrolysis_complex(disilicate(), water(), mode="sideways")
 
     def test_acid_attack_complex_charge(self):
         c = hydrolysis_complex(aluminosilicate_dimer(), hydronium())

--- a/qm/tests/test_ts.py
+++ b/qm/tests/test_ts.py
@@ -170,7 +170,7 @@ class TestScanExtension:
         # Energy profile: rises to a peak at r=1.92 then falls.
         profile = {2.0: 1.0, 1.92: 2.0, 1.84: 1.5}
 
-        def fake_scan(cluster, settings, *, atom_i, atom_j, distances_a, max_steps=150):
+        def fake_scan(cluster, settings, *, atom_i, atom_j, distances_a, **kwargs):
             return [self._fake_point(r, profile[round(r, 2)]) for r in distances_a]
 
         monkeypatch.setattr(ts_mod, "constrained_scan", fake_scan)
@@ -187,11 +187,11 @@ class TestScanExtension:
     def test_scan_raises_at_floor_without_peak(self, monkeypatch):
         import quarry.ts as ts_mod
 
-        def fake_scan(cluster, settings, *, atom_i, atom_j, distances_a, max_steps=150):
+        def fake_scan(cluster, settings, *, atom_i, atom_j, distances_a, **kwargs):
             return [self._fake_point(r, 3.0 - r) for r in distances_a]
 
         monkeypatch.setattr(ts_mod, "constrained_scan", fake_scan)
-        with pytest.raises(RuntimeError, match="interior"):
+        with pytest.raises(ts_mod.ScanNoMaximumError, match="interior") as exc_info:
             ts_mod.scan_to_maximum(
                 Cluster("x", ["H"], np.zeros((1, 3))),
                 CHEAP,
@@ -199,6 +199,30 @@ class TestScanExtension:
                 atom_j=0,
                 distances_a=[1.8, 1.75],
             )
+        # The exception carries the scan so callers can pivot to a
+        # second coordinate from the best structure already computed.
+        assert len(exc_info.value.scan) >= 2
+        assert exc_info.value.scan[0][0] == 1.8
+
+    def test_fixed_distances_held_during_scan(self):
+        from quarry.ts import constrained_scan
+
+        w = optimize(water(), CHEAP)
+        scan = constrained_scan(
+            w,
+            CHEAP,
+            atom_i=0,
+            atom_j=1,
+            distances_a=[1.15],
+            fixed_distances=[(0, 2, 1.05)],
+        )
+        _, _, cl = scan[0]
+        assert np.linalg.norm(cl.coords[0] - cl.coords[1]) == pytest.approx(
+            1.15, abs=0.01
+        )
+        assert np.linalg.norm(cl.coords[0] - cl.coords[2]) == pytest.approx(
+            1.05, abs=0.01
+        )
 
 
 class TestVerifyTs:

--- a/qm/tests/test_ts.py
+++ b/qm/tests/test_ts.py
@@ -140,6 +140,62 @@ class TestConstraints:
         assert not np.allclose(opt.coords[2], w.coords[2], atol=1e-3)
 
 
+class TestScanExtension:
+    @staticmethod
+    def _fake_point(r, e):
+        cl = Cluster(f"p-r{r:.2f}", ["H"], np.zeros((1, 3)))
+        return (r, e, cl)
+
+    def test_interior_maximum_detection(self):
+        from quarry.ts import has_interior_maximum
+
+        rising = [
+            self._fake_point(r, e) for r, e in [(2.8, 0.0), (2.4, 1.0), (2.0, 2.0)]
+        ]
+        peaked = [
+            self._fake_point(r, e) for r, e in [(2.8, 0.0), (2.4, 2.0), (2.0, 1.0)]
+        ]
+        assert not has_interior_maximum(rising)
+        assert has_interior_maximum(peaked)
+        assert not has_interior_maximum(peaked[:2])  # too short to say
+
+    def test_scan_extends_until_peak(self, monkeypatch):
+        import quarry.ts as ts_mod
+
+        # Energy profile: rises to a peak at r=1.92 then falls.
+        profile = {2.0: 1.0, 1.92: 2.0, 1.84: 1.5}
+
+        def fake_scan(cluster, settings, *, atom_i, atom_j, distances_a, max_steps=150):
+            return [self._fake_point(r, profile[round(r, 2)]) for r in distances_a]
+
+        monkeypatch.setattr(ts_mod, "constrained_scan", fake_scan)
+        scan = ts_mod.scan_to_maximum(
+            Cluster("x", ["H"], np.zeros((1, 3))),
+            CHEAP,
+            atom_i=0,
+            atom_j=0,
+            distances_a=[2.0, 1.92],
+        )
+        assert [round(r, 2) for r, _, _ in scan] == [2.0, 1.92, 1.84]
+        assert ts_mod.scan_maximum(scan).name == "p-r1.92"
+
+    def test_scan_raises_at_floor_without_peak(self, monkeypatch):
+        import quarry.ts as ts_mod
+
+        def fake_scan(cluster, settings, *, atom_i, atom_j, distances_a, max_steps=150):
+            return [self._fake_point(r, 3.0 - r) for r in distances_a]
+
+        monkeypatch.setattr(ts_mod, "constrained_scan", fake_scan)
+        with pytest.raises(RuntimeError, match="interior"):
+            ts_mod.scan_to_maximum(
+                Cluster("x", ["H"], np.zeros((1, 3))),
+                CHEAP,
+                atom_i=0,
+                atom_j=0,
+                distances_a=[1.8, 1.75],
+            )
+
+
 class TestVerifyTs:
     def test_minimum_rejected_as_ts(self):
         w = optimize(water(), CHEAP)


### PR DESCRIPTION
## Summary
The first live si-neutral saddle search converged mechanically but to the wrong saddle: a 208i cm⁻¹ water-wag with ΔG‡ = 2.5 kJ/mol (literature: ~120 kJ/mol). Root cause: the r(Si–O_w) scan ended at 1.9 Å with energy still rising monotonically, so the scan *endpoint* — not a ridge crossing — became the Sella guess, and the search slid back into the reactant basin (converged saddle at r(Si–O_w)=3.25 Å; both quick-IRC ends relax to the reactant complex).

- `scan_to_maximum` keeps tightening the driven distance by 0.08 Å until the energy maximum is interior; below a 1.6 Å floor it raises instead of handing a known-bad guess onward (that usually means the single driven coordinate can't cross the ridge alone)
- Driver aborts loudly before thermochemistry when the converged saddle's r(Si–O_w) grew > 0.5 Å past the guess (the escaped-channel signature), instead of reporting a plausible-looking wrong barrier
- Monkeypatched unit tests cover interior-maximum detection, the extension loop, and the floor error

## Test plan
- 82 tests green, ruff clean
- Live validation: relaunch si-neutral from stage-1 checkpoints; the scan should now continue past 1.9 Å until the proton-transfer ridge appears, and the guard blocks any repeat of the trivial-saddle outcome

## Breaking changes
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Harden hydrolysis transition-state generation by requiring reaction-ridge crossing and rejecting saddle searches that escape the intended approach channel.

New Features:
- Add adaptive transition-state scans that extend until they identify an interior energy maximum and support additional fixed distances.
- Add climbing-image NEB transition-state guesses for cases where a single driven coordinate cannot cross the reaction ridge.
- Add selectable flank and backside hydrolysis attack geometries, including proton-transfer-capable flank arrangements.

Bug Fixes:
- Prevent uncrossed scan endpoints and escaped saddle searches from producing chemically incorrect transition states or misleading thermochemistry.

Enhancements:
- Improve hydrolysis transition-state generation with concerted proton-transfer fallback scans and channel-escape validation.
- Add coverage for scan peak detection, scan extension and floor failures, constrained distances, NEB guesses, and attack geometry validation.

Documentation:
- Document the trivial-saddle failure mode and the requirement for an interior scan maximum.

Tests:
- Expand transition-state and hydrolysis geometry tests for NEB, adaptive scans, fixed constraints, attack modes, and invalid modes.