### PR TITLE
qm: repair path-dependent scan spikes

### DIFF
--- a/qm/quarry/ts.py
+++ b/qm/quarry/ts.py
@@ -18,6 +18,7 @@ import numpy as np
 
 from quarry.clusters import Cluster
 from quarry.pipeline import (
+    HARTREE_TO_KJ,
     DftSettings,
     FrequencyResult,
     _make_scf,
@@ -195,6 +196,74 @@ def scan_maximum(scan: list[tuple[float, float, Cluster]]) -> Cluster:
 # Peaks must clear both neighbors by this much (Hartree) to count —
 # well above converged-optimization noise, well below any real barrier.
 _PEAK_TOL_HARTREE = 5e-5
+# A single constrained optimization can hop into a bad peripheral-hydroxyl
+# conformer while its neighbors remain on the reaction path.  The live
+# al-neutral scan produced a 117 kJ/mol spike followed by an 84 kJ/mol drop.
+# A genuine crest that both neighboring seeds reproduce is retained; only the
+# one-direction path-dependent result is replaced.
+_SCAN_OUTLIER_THRESHOLD_KJ = 40.0
+
+
+def _scan_outlier_indices(
+    scan: list[tuple[float, float, Cluster]],
+    *,
+    threshold_kj: float = _SCAN_OUTLIER_THRESHOLD_KJ,
+) -> list[int]:
+    """Return interior points far above linear neighbor interpolation."""
+    threshold_hartree = threshold_kj / HARTREE_TO_KJ
+    outliers = []
+    for i in range(1, len(scan) - 1):
+        r_left, e_left, _ = scan[i - 1]
+        r, energy, _ = scan[i]
+        r_right, e_right, _ = scan[i + 1]
+        if r_right == r_left:
+            continue
+        fraction = (r - r_left) / (r_right - r_left)
+        interpolated = e_left + fraction * (e_right - e_left)
+        if energy > interpolated + threshold_hartree:
+            outliers.append(i)
+    return outliers
+
+
+def _repair_scan_outliers(
+    scan: list[tuple[float, float, Cluster]],
+    settings: DftSettings,
+    *,
+    atom_i: int,
+    atom_j: int,
+    fixed_distances: list[tuple[int, int, float]],
+    max_steps: int,
+    attempted: set[int],
+    progress=None,
+) -> None:
+    """Reoptimize each new spike from both neighboring scan structures.
+
+    ``attempted`` persists while a scan is extended.  A point reproduced as
+    high energy from both directions may be a real sharp crest, so it is
+    checked once and then left for crest detection rather than retried forever.
+    """
+    while True:
+        indices = [i for i in _scan_outlier_indices(scan) if i not in attempted]
+        if not indices:
+            return
+        for i in indices:
+            attempted.add(i)
+            r = scan[i][0]
+            retries = []
+            for seed in (scan[i - 1][2], scan[i + 1][2]):
+                result = constrained_scan(
+                    seed,
+                    settings,
+                    atom_i=atom_i,
+                    atom_j=atom_j,
+                    distances_a=[r],
+                    fixed_distances=fixed_distances,
+                    max_steps=max_steps,
+                )[0]
+                retries.append(result)
+                if progress:
+                    progress(result[0], result[1])
+            scan[i] = min(retries, key=lambda point: point[1])
 
 
 def first_interior_maximum(
@@ -341,6 +410,17 @@ def scan_to_maximum(
     if progress:
         for r, e, _ in scan:
             progress(r, e)
+    repaired_indices: set[int] = set()
+    _repair_scan_outliers(
+        scan,
+        settings,
+        atom_i=atom_i,
+        atom_j=atom_j,
+        fixed_distances=fixed_distances,
+        max_steps=max_steps,
+        attempted=repaired_indices,
+        progress=progress,
+    )
     while not has_interior_maximum(scan):
         next_r = round(scan[-1][0] - extend_step_a, 3)
         if next_r < min_distance_a:
@@ -364,4 +444,14 @@ def scan_to_maximum(
             for r, e, _ in ext:
                 progress(r, e)
         scan.extend(ext)
+        _repair_scan_outliers(
+            scan,
+            settings,
+            atom_i=atom_i,
+            atom_j=atom_j,
+            fixed_distances=fixed_distances,
+            max_steps=max_steps,
+            attempted=repaired_indices,
+            progress=progress,
+        )
     return scan

--- a/qm/scripts/phase1_xiao_lasaga.py
+++ b/qm/scripts/phase1_xiao_lasaga.py
@@ -58,6 +58,7 @@ from quarry.rates import rate_from_thermo, thermo_from_frequencies  # noqa: E402
 from quarry.store import Store  # noqa: E402
 from quarry.ts import (  # noqa: E402
     ScanNoMaximumError,
+    constrained_scan,
     find_ts,
     first_interior_maximum,
     neb_ts_guess,
@@ -106,6 +107,109 @@ def checkpointed(path: Path, template: Cluster, compute) -> Cluster:
     result = compute()
     save_xyz(result, path)
     return result
+
+
+def channel_escape_reason(ts_guess: Cluster, ts: Cluster, ow_index: int) -> str | None:
+    """Explain why a refined saddle left the hydrolysis channel, if it did."""
+    r_guess = float(
+        np.linalg.norm(ts_guess.coords[SI_INDEX] - ts_guess.coords[ow_index])
+    )
+    r_ts = float(np.linalg.norm(ts.coords[SI_INDEX] - ts.coords[ow_index]))
+    if r_ts > 2.6:
+        return f"saddle r(Si-Ow)={r_ts:.2f} A is outside the bonding channel"
+    if r_ts > r_guess + 0.5:
+        return f"saddle escaped the approach channel by {r_ts - r_guess:.2f} A"
+    return None
+
+
+def proton_neb_guess(
+    approach_seed: Cluster,
+    complex_opt: Cluster,
+    settings: DftSettings,
+    run_dir: Path,
+    ow_index: int,
+) -> Cluster:
+    """Build the concerted proton-transfer/product/CI-NEB TS guess.
+
+    ``approach_seed`` may be the r=1.90 A point from a completed scan or a
+    resumed direct-crest checkpoint.  In the latter case, reconstruct only
+    the missing 1.90 A approach point instead of rerunning the whole scan.
+    """
+    seed_r = float(
+        np.linalg.norm(approach_seed.coords[SI_INDEX] - approach_seed.coords[ow_index])
+    )
+    if abs(seed_r - 1.90) > 0.02:
+        log(f"  pinning resumed approach seed: r(Si-Ow) {seed_r:.2f} -> 1.90 A")
+        approach_seed = constrained_scan(
+            approach_seed,
+            settings,
+            atom_i=SI_INDEX,
+            atom_j=ow_index,
+            distances_a=[1.90],
+        )[0][2]
+
+    log("  stage 2b: pin r(Si-Ow)=1.90 A, drive H(water) -> O(bridge)")
+    h_candidates = [ow_index + 1, ow_index + 2]
+    h_idx = min(
+        h_candidates,
+        key=lambda i: np.linalg.norm(
+            approach_seed.coords[i] - approach_seed.coords[BR_INDEX]
+        ),
+    )
+    r0 = float(
+        np.linalg.norm(approach_seed.coords[h_idx] - approach_seed.coords[BR_INDEX])
+    )
+    log(f"  driving H{h_idx} from r(Obr-H)={r0:.2f} A inward")
+    first = max(1.05, round(r0 - 0.15, 2))
+    distances = [round(float(x), 2) for x in np.arange(first, 1.04, -0.15)]
+    pscan = scan_to_maximum(
+        approach_seed,
+        settings,
+        atom_i=BR_INDEX,
+        atom_j=h_idx,
+        distances_a=distances or [first],
+        fixed_distances=[(SI_INDEX, ow_index, 1.90)],
+        extend_step_a=0.06,
+        min_distance_a=0.95,
+        progress=lambda r, e: log(f"  r(Obr-H)={r:.2f} A  E={e:.6f} Ha"),
+    )
+    crest_idx = first_interior_maximum(pscan)
+    if crest_idx is None:
+        raise RuntimeError("proton scan produced no interior crest")
+    seed_idx = min(crest_idx + 1, len(pscan) - 1)
+
+    def build_product():
+        log("  stage 2c: breaking Si-Obr with the new bonds held")
+        broken = constrained_scan(
+            pscan[seed_idx][2],
+            settings,
+            atom_i=SI_INDEX,
+            atom_j=BR_INDEX,
+            distances_a=[1.85, 2.05, 2.30, 2.60],
+            fixed_distances=[
+                (SI_INDEX, ow_index, 1.70),
+                (BR_INDEX, h_idx, 0.98),
+            ],
+        )
+        for r, e, _ in broken:
+            log(f"  r(Si-Obr)={r:.2f} A  E={e:.6f} Ha")
+        return optimize(broken[-1][2], settings)
+
+    product = checkpointed(run_dir / "product.xyz", pscan[seed_idx][2], build_product)
+    r_prod_ow = float(
+        np.linalg.norm(product.coords[SI_INDEX] - product.coords[ow_index])
+    )
+    r_prod_br = float(
+        np.linalg.norm(product.coords[SI_INDEX] - product.coords[BR_INDEX])
+    )
+    log(f"  product r(Si-Ow)={r_prod_ow:.2f} A, r(Si-Obr)={r_prod_br:.2f} A")
+    if r_prod_ow > 1.9 or r_prod_br < 2.2:
+        raise RuntimeError(
+            "product rolled back toward reactants; expected Si-Ow bonded "
+            "and Si-Obr broken"
+        )
+    log("  stage 2d: CI-NEB complex -> product (7 images)")
+    return neb_ts_guess(complex_opt, product, settings)
 
 
 def main() -> int:
@@ -189,10 +293,16 @@ def main() -> int:
     # bridging O — the concerted proton transfer of the X&L TS.
     log("stage 2: relaxed scan r(Si-Ow), auto-extending to interior maximum")
     ts_guess_path = run_dir / "ts_guess.xyz"
+    route_path = run_dir / "ts_guess.route"
+    route = route_path.read_text().strip() if route_path.exists() else "direct"
     if ts_guess_path.exists():
         ts_guess = load_xyz(ts_guess_path, complex_opt)
-        log("  resume: ts_guess.xyz exists")
+        log(f"  resume: ts_guess.xyz exists ({route} route)")
     else:
+        # A route marker without its geometry can only be a crash between
+        # checkpoint writes. Reconstruct from the direct route safely.
+        route = "direct"
+        route_path.unlink(missing_ok=True)
         try:
             scan = scan_to_maximum(
                 complex_opt,
@@ -205,118 +315,62 @@ def main() -> int:
             ts_guess = scan_ts_guess(scan)
         except ScanNoMaximumError as exc:
             log("  approach coordinate alone does not cross the ridge;")
-            log("  stage 2b: pin r(Si-Ow)=1.90 A, drive H(water) -> O(bridge)")
             base = min(exc.scan, key=lambda p: abs(p[0] - 1.90))[2]
-            # The water H closest to the bridging O is the one to shuttle.
-            h_candidates = [ow_index + 1, ow_index + 2]
-            h_idx = min(
-                h_candidates,
-                key=lambda i: np.linalg.norm(base.coords[i] - base.coords[BR_INDEX]),
-            )
-            r0 = float(np.linalg.norm(base.coords[h_idx] - base.coords[BR_INDEX]))
-            log(f"  driving H{h_idx} from r(Obr-H)={r0:.2f} A inward")
-            first = max(1.05, round(r0 - 0.15, 2))
-            distances = [round(x, 2) for x in np.arange(first, 1.04, -0.15)]
-            pscan = scan_to_maximum(
-                base,
-                settings,
-                atom_i=BR_INDEX,
-                atom_j=h_idx,
-                distances_a=distances or [first],
-                fixed_distances=[(SI_INDEX, ow_index, 1.90)],
-                extend_step_a=0.06,
-                min_distance_a=0.95,
-                progress=lambda r, e: log(f"  r(Obr-H)={r:.2f} A  E={e:.6f} Ha"),
-            )
-            # A raw crest guess lets Sella escape the channel (measured:
-            # r(Si-Ow) 1.90 -> 3.22). And a bare free relax of the
-            # post-crest structure rolls BACK to reactants (measured:
-            # product r(Si-Ow)=3.16 — proton returned, water left):
-            # a single proton transfer with the bridge intact is not a
-            # minimum. Hydrolysis completes by Si-Obr cleavage, so build
-            # the product deliberately: hold the new bonds, break the
-            # bridge, then free-optimize into 2 Si(OH)4.
-            crest_idx = first_interior_maximum(pscan)
-            if crest_idx is None:
-                log("  !! proton scan produced no crest either — aborting")
-                return 1
-            seed_idx = min(crest_idx + 1, len(pscan) - 1)
-
-            def build_product():
-                log("  stage 2c: breaking Si-Obr with the new bonds held")
-                from quarry.ts import constrained_scan
-
-                broken = constrained_scan(
-                    pscan[seed_idx][2],
-                    settings,
-                    atom_i=SI_INDEX,
-                    atom_j=BR_INDEX,
-                    distances_a=[1.85, 2.05, 2.30, 2.60],
-                    fixed_distances=[
-                        (SI_INDEX, ow_index, 1.70),
-                        (BR_INDEX, h_idx, 0.98),
-                    ],
-                )
-                for r, e, _ in broken:
-                    log(f"  r(Si-Obr)={r:.2f} A  E={e:.6f} Ha")
-                return optimize(broken[-1][2], settings)
-
-            product = checkpointed(
-                run_dir / "product.xyz", pscan[seed_idx][2], build_product
-            )
-            r_prod_ow = float(
-                np.linalg.norm(product.coords[SI_INDEX] - product.coords[ow_index])
-            )
-            r_prod_br = float(
-                np.linalg.norm(product.coords[SI_INDEX] - product.coords[BR_INDEX])
-            )
-            log(f"  product r(Si-Ow)={r_prod_ow:.2f} A, r(Si-Obr)={r_prod_br:.2f} A")
-            if r_prod_ow > 1.9 or r_prod_br < 2.2:
-                log(
-                    "  !! product rolled back toward reactants "
-                    "(hydrolyzed minimum requires Si-Ow bonded, Si-Obr "
-                    "broken) — aborting; inspect product.xyz"
-                )
-                return 1
-            log("  stage 2d: CI-NEB complex -> product (7 images)")
-            ts_guess = neb_ts_guess(complex_opt, product, settings)
+            ts_guess = proton_neb_guess(base, complex_opt, settings, run_dir, ow_index)
+            route = "proton-neb"
         save_xyz(ts_guess, ts_guess_path)
+        if route == "proton-neb":
+            route_path.write_text(route)
 
-    # Stage 3 — saddle search.
+    # Stage 3 — saddle search. A direct approach crest gets one bounded
+    # fallback through the concerted proton/product/CI-NEB route if Sella
+    # escapes. A proton-NEB saddle that escapes is terminal.
     log("stage 3: Sella saddle search")
+    ts_path = run_dir / "ts.xyz"
+    trajectory_path = run_dir / "sella.traj"
     ts = checkpointed(
-        run_dir / "ts.xyz",
+        ts_path,
         ts_guess,
-        lambda: find_ts(ts_guess, settings, trajectory=str(run_dir / "sella.traj")),
+        lambda: find_ts(ts_guess, settings, trajectory=str(trajectory_path)),
     )
 
-    # Guard: a saddle that drifted back out of the approach channel is a
-    # trivial complex-rearrangement saddle, not the hydrolysis TS
-    # (observed live: 208i water wag at r(Si-Ow)=3.25 from a bad guess).
     r_guess = float(
         np.linalg.norm(ts_guess.coords[SI_INDEX] - ts_guess.coords[ow_index])
     )
     r_ts = float(np.linalg.norm(ts.coords[SI_INDEX] - ts.coords[ow_index]))
     log(f"  r(Si-Ow): guess {r_guess:.2f} A -> saddle {r_ts:.2f} A")
-    # The 4-center hydrolysis saddle is in-channel by construction:
-    # forming Si-Ow bond ~1.8-2.2 A. A saddle sitting outside bonding
-    # range is a complex-rearrangement saddle whatever its history
-    # (observed live: 45.7i at r(Si-Ow)=3.15 from a reactant-conformer
-    # NEB after the product basin escaped).
-    if r_ts > 2.6:
-        log(
-            f"  !! saddle at r(Si-Ow)={r_ts:.2f} A is outside the bonding "
-            "channel — not the hydrolysis TS. Aborting before "
-            "thermochemistry; inspect ts.xyz and product.xyz."
+    escape = channel_escape_reason(ts_guess, ts, ow_index)
+    if escape and route == "direct":
+        log(f"  !! {escape}; pivoting once to proton-drive + product + CI-NEB")
+        neb_guess = proton_neb_guess(ts_guess, complex_opt, settings, run_dir, ow_index)
+
+        # Preserve the rejected direct-search receipt, then replace all
+        # resumable checkpoints with the new route before refining again.
+        rejected_ts = run_dir / "ts.rejected-direct.xyz"
+        if ts_path.exists():
+            ts_path.replace(rejected_ts)
+        rejected_traj = run_dir / "sella.rejected-direct.traj"
+        if trajectory_path.exists():
+            trajectory_path.replace(rejected_traj)
+        ts_guess = neb_guess
+        save_xyz(ts_guess, ts_guess_path)
+        route = "proton-neb"
+        route_path.write_text(route)
+
+        log("stage 3b: Sella saddle search from CI-NEB guess")
+        ts = checkpointed(
+            ts_path,
+            ts_guess,
+            lambda: find_ts(ts_guess, settings, trajectory=str(trajectory_path)),
         )
-        return 1
-    if r_ts > r_guess + 0.5:
-        log(
-            "  !! saddle escaped the approach channel (r(Si-Ow) grew by "
-            f"{r_ts - r_guess:.2f} A) — this is not the hydrolysis TS. "
-            "Delete ts.xyz/ts_guess.xyz and rerun with a tighter scan, or "
-            "drive a combined coordinate. Aborting before thermochemistry."
+        r_guess = float(
+            np.linalg.norm(ts_guess.coords[SI_INDEX] - ts_guess.coords[ow_index])
         )
+        r_ts = float(np.linalg.norm(ts.coords[SI_INDEX] - ts.coords[ow_index]))
+        log(f"  r(Si-Ow): NEB guess {r_guess:.2f} A -> saddle {r_ts:.2f} A")
+        escape = channel_escape_reason(ts_guess, ts, ow_index)
+    if escape:
+        log(f"  !! {escape}; {route} route exhausted — aborting before thermochemistry")
         return 1
 
     # Stage 4 — verify + quick IRC.

--- a/qm/scripts/phase1_xiao_lasaga.py
+++ b/qm/scripts/phase1_xiao_lasaga.py
@@ -132,70 +132,111 @@ def proton_neb_guess(
     """Build the concerted proton-transfer/product/CI-NEB TS guess.
 
     ``approach_seed`` may be the r=1.90 A point from a completed scan or a
-    resumed direct-crest checkpoint.  In the latter case, reconstruct only
-    the missing 1.90 A approach point instead of rerunning the whole scan.
+    resumed direct-crest checkpoint. Existing product checkpoints are
+    validated before reuse; a rolled-back product is extended farther along
+    Si-Obr cleavage rather than repeating the expensive proton scan.
     """
-    seed_r = float(
-        np.linalg.norm(approach_seed.coords[SI_INDEX] - approach_seed.coords[ow_index])
-    )
-    if abs(seed_r - 1.90) > 0.02:
-        log(f"  pinning resumed approach seed: r(Si-Ow) {seed_r:.2f} -> 1.90 A")
-        approach_seed = constrained_scan(
+    product_path = run_dir / "product.xyz"
+    product_seed: Cluster | None = None
+    h_candidates = [ow_index + 1, ow_index + 2]
+
+    if product_path.exists():
+        product = load_xyz(product_path, approach_seed)
+        r_prod_ow = float(
+            np.linalg.norm(product.coords[SI_INDEX] - product.coords[ow_index])
+        )
+        r_prod_br = float(
+            np.linalg.norm(product.coords[SI_INDEX] - product.coords[BR_INDEX])
+        )
+        log(
+            "  resume: product.xyz exists; "
+            f"r(Si-Ow)={r_prod_ow:.2f} A, r(Si-Obr)={r_prod_br:.2f} A"
+        )
+        if r_prod_ow <= 1.9 and r_prod_br >= 2.2:
+            log("  stage 2d: CI-NEB complex -> product (7 images)")
+            return neb_ts_guess(complex_opt, product, settings)
+        log("  saved product is not hydrolyzed; extending Si-Obr cleavage")
+        rejected = run_dir / "product.rejected-rollback.xyz"
+        product_path.replace(rejected)
+        product_seed = product
+
+    if product_seed is None:
+        seed_r = float(
+            np.linalg.norm(
+                approach_seed.coords[SI_INDEX] - approach_seed.coords[ow_index]
+            )
+        )
+        if abs(seed_r - 1.90) > 0.02:
+            log(f"  pinning resumed approach seed: r(Si-Ow) {seed_r:.2f} -> 1.90 A")
+            approach_seed = constrained_scan(
+                approach_seed,
+                settings,
+                atom_i=SI_INDEX,
+                atom_j=ow_index,
+                distances_a=[1.90],
+            )[0][2]
+
+        log("  stage 2b: pin r(Si-Ow)=1.90 A, drive H(water) -> O(bridge)")
+        h_idx = min(
+            h_candidates,
+            key=lambda i: np.linalg.norm(
+                approach_seed.coords[i] - approach_seed.coords[BR_INDEX]
+            ),
+        )
+        r0 = float(
+            np.linalg.norm(approach_seed.coords[h_idx] - approach_seed.coords[BR_INDEX])
+        )
+        log(f"  driving H{h_idx} from r(Obr-H)={r0:.2f} A inward")
+        first = max(1.05, round(r0 - 0.15, 2))
+        distances = [round(float(x), 2) for x in np.arange(first, 1.04, -0.15)]
+        pscan = scan_to_maximum(
             approach_seed,
             settings,
-            atom_i=SI_INDEX,
-            atom_j=ow_index,
-            distances_a=[1.90],
-        )[0][2]
+            atom_i=BR_INDEX,
+            atom_j=h_idx,
+            distances_a=distances or [first],
+            fixed_distances=[(SI_INDEX, ow_index, 1.90)],
+            extend_step_a=0.06,
+            min_distance_a=0.95,
+            progress=lambda r, e: log(f"  r(Obr-H)={r:.2f} A  E={e:.6f} Ha"),
+        )
+        crest_idx = first_interior_maximum(pscan)
+        if crest_idx is None:
+            raise RuntimeError("proton scan produced no interior crest")
+        product_seed = pscan[min(crest_idx + 1, len(pscan) - 1)][2]
 
-    log("  stage 2b: pin r(Si-Ow)=1.90 A, drive H(water) -> O(bridge)")
-    h_candidates = [ow_index + 1, ow_index + 2]
     h_idx = min(
         h_candidates,
         key=lambda i: np.linalg.norm(
-            approach_seed.coords[i] - approach_seed.coords[BR_INDEX]
+            product_seed.coords[i] - product_seed.coords[BR_INDEX]
         ),
     )
-    r0 = float(
-        np.linalg.norm(approach_seed.coords[h_idx] - approach_seed.coords[BR_INDEX])
+    current_br = float(
+        np.linalg.norm(product_seed.coords[SI_INDEX] - product_seed.coords[BR_INDEX])
     )
-    log(f"  driving H{h_idx} from r(Obr-H)={r0:.2f} A inward")
-    first = max(1.05, round(r0 - 0.15, 2))
-    distances = [round(float(x), 2) for x in np.arange(first, 1.04, -0.15)]
-    pscan = scan_to_maximum(
-        approach_seed,
+    break_targets = [
+        r for r in [1.85, 2.05, 2.30, 2.60, 3.00, 3.40, 3.60] if r > current_br + 0.05
+    ]
+    if not break_targets:
+        break_targets = [round(current_br + 0.30, 2)]
+
+    log("  stage 2c: breaking Si-Obr with the new bonds held")
+    broken = constrained_scan(
+        product_seed,
         settings,
-        atom_i=BR_INDEX,
-        atom_j=h_idx,
-        distances_a=distances or [first],
-        fixed_distances=[(SI_INDEX, ow_index, 1.90)],
-        extend_step_a=0.06,
-        min_distance_a=0.95,
-        progress=lambda r, e: log(f"  r(Obr-H)={r:.2f} A  E={e:.6f} Ha"),
+        atom_i=SI_INDEX,
+        atom_j=BR_INDEX,
+        distances_a=break_targets,
+        fixed_distances=[
+            (SI_INDEX, ow_index, 1.70),
+            (BR_INDEX, h_idx, 0.98),
+        ],
     )
-    crest_idx = first_interior_maximum(pscan)
-    if crest_idx is None:
-        raise RuntimeError("proton scan produced no interior crest")
-    seed_idx = min(crest_idx + 1, len(pscan) - 1)
+    for r, e, _ in broken:
+        log(f"  r(Si-Obr)={r:.2f} A  E={e:.6f} Ha")
+    product = optimize(broken[-1][2], settings)
+    save_xyz(product, product_path)
 
-    def build_product():
-        log("  stage 2c: breaking Si-Obr with the new bonds held")
-        broken = constrained_scan(
-            pscan[seed_idx][2],
-            settings,
-            atom_i=SI_INDEX,
-            atom_j=BR_INDEX,
-            distances_a=[1.85, 2.05, 2.30, 2.60],
-            fixed_distances=[
-                (SI_INDEX, ow_index, 1.70),
-                (BR_INDEX, h_idx, 0.98),
-            ],
-        )
-        for r, e, _ in broken:
-            log(f"  r(Si-Obr)={r:.2f} A  E={e:.6f} Ha")
-        return optimize(broken[-1][2], settings)
-
-    product = checkpointed(run_dir / "product.xyz", pscan[seed_idx][2], build_product)
     r_prod_ow = float(
         np.linalg.norm(product.coords[SI_INDEX] - product.coords[ow_index])
     )

--- a/qm/tests/test_phase1_driver.py
+++ b/qm/tests/test_phase1_driver.py
@@ -1,0 +1,88 @@
+"""Fast orchestration gates for the Xiao & Lasaga Phase-1 driver."""
+
+import numpy as np
+
+from quarry.clusters import Cluster
+from quarry.pipeline import DftSettings
+from scripts import phase1_xiao_lasaga as phase1
+
+CHEAP = DftSettings(xc="hf", basis="sto-3g")
+
+
+def geometry(name: str, si_ow: float, si_obr: float = 1.6) -> Cluster:
+    return Cluster(
+        name=name,
+        symbols=["O", "Si", "O", "H", "H"],
+        coords=np.array(
+            [
+                [si_obr, 0.0, 0.0],
+                [0.0, 0.0, 0.0],
+                [si_ow, 0.0, 0.0],
+                [si_ow, 0.9, 0.0],
+                [si_ow, -0.9, 0.0],
+            ]
+        ),
+    )
+
+
+def test_channel_escape_guard_is_absolute_and_relative():
+    guess = geometry("guess", 2.2)
+    outside = phase1.channel_escape_reason(guess, geometry("far", 2.7), 2)
+    relative = phase1.channel_escape_reason(
+        geometry("tight-guess", 1.8), geometry("drift", 2.4), 2
+    )
+
+    assert outside is not None and "outside" in outside
+    assert relative is not None and "escaped" in relative
+    assert phase1.channel_escape_reason(guess, geometry("channel", 2.4), 2) is None
+
+
+def test_proton_neb_fallback_reconstructs_resumed_approach_seed(monkeypatch, tmp_path):
+    direct_crest = geometry("direct-crest", 2.2)
+    complex_opt = geometry("complex", 3.2)
+    calls = []
+
+    def fake_constrained_scan(
+        cluster,
+        settings,
+        *,
+        atom_i,
+        atom_j,
+        distances_a,
+        fixed_distances=(),
+        **kwargs,
+    ):
+        calls.append((cluster.name, atom_i, atom_j, distances_a, fixed_distances))
+        if (atom_i, atom_j) == (phase1.SI_INDEX, 2):
+            return [(1.90, -1.0, geometry("approach-r1.90", 1.90))]
+        broken = geometry("broken", 1.70, si_obr=2.60)
+        return [(r, -2.0, broken) for r in distances_a]
+
+    def fake_proton_scan(cluster, settings, **kwargs):
+        points = [
+            (1.40, 0.0, geometry("proton-start", 1.90)),
+            (1.25, 2.0, geometry("proton-crest", 1.90)),
+            (1.10, 1.0, geometry("proton-product-seed", 1.90)),
+        ]
+        return points
+
+    neb_inputs = []
+
+    def fake_neb(reactant, product, settings):
+        neb_inputs.append((reactant, product))
+        return geometry("neb-guess", 2.0)
+
+    monkeypatch.setattr(phase1, "constrained_scan", fake_constrained_scan)
+    monkeypatch.setattr(phase1, "scan_to_maximum", fake_proton_scan)
+    monkeypatch.setattr(phase1, "optimize", lambda cluster, settings: cluster)
+    monkeypatch.setattr(phase1, "neb_ts_guess", fake_neb)
+
+    result = phase1.proton_neb_guess(direct_crest, complex_opt, CHEAP, tmp_path, 2)
+
+    assert result.name == "neb-guess"
+    assert calls[0][1:4] == (phase1.SI_INDEX, 2, [1.90])
+    assert neb_inputs[0][0] is complex_opt
+    assert (
+        np.linalg.norm(neb_inputs[0][1].coords[1] - neb_inputs[0][1].coords[2]) == 1.70
+    )
+    assert (tmp_path / "product.xyz").exists()

--- a/qm/tests/test_phase1_driver.py
+++ b/qm/tests/test_phase1_driver.py
@@ -86,3 +86,40 @@ def test_proton_neb_fallback_reconstructs_resumed_approach_seed(monkeypatch, tmp
         np.linalg.norm(neb_inputs[0][1].coords[1] - neb_inputs[0][1].coords[2]) == 1.70
     )
     assert (tmp_path / "product.xyz").exists()
+
+
+def test_rolled_back_product_extends_cleavage_without_repeating_proton_scan(
+    monkeypatch, tmp_path
+):
+    direct_crest = geometry("direct-crest", 2.2)
+    complex_opt = geometry("complex", 3.2)
+    phase1.save_xyz(
+        geometry("rolled-back", 1.70, si_obr=2.07), tmp_path / "product.xyz"
+    )
+    break_targets = []
+
+    def fake_break_scan(cluster, settings, *, distances_a, **kwargs):
+        break_targets.extend(distances_a)
+        broken = geometry("fully-broken", 1.70, si_obr=3.60)
+        return [(r, -2.0, broken) for r in distances_a]
+
+    monkeypatch.setattr(phase1, "constrained_scan", fake_break_scan)
+    monkeypatch.setattr(
+        phase1,
+        "scan_to_maximum",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("proton scan must not repeat")
+        ),
+    )
+    monkeypatch.setattr(phase1, "optimize", lambda cluster, settings: cluster)
+    monkeypatch.setattr(
+        phase1,
+        "neb_ts_guess",
+        lambda reactant, product, settings: geometry("neb-guess", 2.0),
+    )
+
+    result = phase1.proton_neb_guess(direct_crest, complex_opt, CHEAP, tmp_path, 2)
+
+    assert result.name == "neb-guess"
+    assert break_targets == [2.3, 2.6, 3.0, 3.4, 3.6]
+    assert (tmp_path / "product.rejected-rollback.xyz").exists()

--- a/qm/tests/test_ts.py
+++ b/qm/tests/test_ts.py
@@ -222,6 +222,46 @@ class TestScanExtension:
         assert [round(r, 2) for r, _, _ in scan] == [2.0, 1.92, 1.84]
         assert ts_mod.scan_maximum(scan).name == "p-r1.92"
 
+    def test_spike_is_retried_from_both_neighbors_before_crest_detection(
+        self, monkeypatch
+    ):
+        import quarry.ts as ts_mod
+
+        # The r=2.20 point mimics the live al-neutral optimizer hop: it is
+        # >40 kJ/mol above the interpolation of its neighbors and would be
+        # mistaken for the first crest without a bidirectional repair.
+        profile = {
+            2.60: 0.000,
+            2.40: 0.010,
+            2.20: 0.060,
+            2.10: 0.023,
+            2.00: 0.015,
+        }
+        retry_energies = {"p-r2.40": 0.020, "p-r2.10": 0.014}
+        retry_seeds = []
+
+        def fake_scan(cluster, settings, *, atom_i, atom_j, distances_a, **kwargs):
+            if len(distances_a) > 1:
+                return [self._fake_point(r, profile[round(r, 2)]) for r in distances_a]
+            r = distances_a[0]
+            retry_seeds.append(cluster.name)
+            return [self._fake_point(r, retry_energies[cluster.name])]
+
+        monkeypatch.setattr(ts_mod, "constrained_scan", fake_scan)
+        scan = ts_mod.scan_to_maximum(
+            Cluster("x", ["H"], np.zeros((1, 3))),
+            CHEAP,
+            atom_i=0,
+            atom_j=0,
+            distances_a=[2.60, 2.40, 2.20, 2.10, 2.00],
+        )
+
+        assert retry_seeds == ["p-r2.40", "p-r2.10"]
+        assert scan[2][1] == pytest.approx(0.014)
+        assert scan[2][2].name == "p-r2.20"
+        assert ts_mod.first_interior_maximum(scan) == 3
+        assert ts_mod.scan_ts_guess(scan).name == "p-r2.10"
+
     def test_scan_raises_at_floor_without_peak(self, monkeypatch):
         import quarry.ts as ts_mod
 


### PR DESCRIPTION
## Summary
- detect constrained-scan points more than 40 kJ/mol above linear neighbor interpolation
- re-optimize each detected spike from both neighboring structures and retain the lower-energy path before crest detection
- preserve reproducible sharp crests after one bidirectional check and apply the same repair as scans extend
- add a synthetic regression for the observed al-neutral 2.20 Å optimizer-hop profile

## Test plan
- `env -u PYTHONPATH uv run --extra dev python -m pytest -m 'not slow' -q` — 85 passed, 4 deselected
- `env -u PYTHONPATH uv run --extra dev ruff check .`
- `env -u PYTHONPATH uv run --extra dev ruff format --check .`
- `git diff --check`
- workstation `al-neutral` B3LYP/def2-SVP/DF GPU campaign is running separately from preserved stage-0/1 checkpoints with `OMP_NUM_THREADS=16`; its gitignored durable log and final scientific receipt remain queue acceptance, not a claim of this PR

## Breaking changes
None.

## Summary by Sourcery

Make hydrolysis scan and saddle searches robust against optimizer hops and escaped reaction-channel geometries.

New Features:
- Add automatic recovery for escaped hydrolysis saddle searches by rebuilding a proton-transfer/product pathway and retrying the saddle refinement once.
- Add resumable product construction that validates saved products and continues bridge-bond cleavage when necessary.

Bug Fixes:
- Repair path-dependent constrained-scan energy spikes by reoptimizing suspicious points from both neighboring structures and retaining the lower-energy result.
- Prevent escaped saddle searches and rolled-back products from being accepted as valid hydrolysis transition states.

Enhancements:
- Persist route and rejected-search checkpoints so fallback runs remain resumable and preserve diagnostic artifacts.

Tests:
- Add regression coverage for bidirectional scan-spike repair and hydrolysis fallback checkpoint behavior.