### PR TITLE
agents: track AGENTS.md, add repo skills + permission allowlist

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,1 +1,23 @@
-{}
+{
+  "permissions": {
+    "allow": [
+      "Bash(cargo build:*)",
+      "Bash(cargo test:*)",
+      "Bash(cargo run -p petra-cli:*)",
+      "Bash(cargo clippy:*)",
+      "Bash(uv sync:*)",
+      "Bash(uv run pytest:*)",
+      "Bash(uv run ruff:*)",
+      "Bash(npm run lint:*)",
+      "Bash(npm test:*)",
+      "Bash(git status:*)",
+      "Bash(git log:*)",
+      "Bash(git diff:*)",
+      "Bash(git ls-remote:*)",
+      "Bash(git fetch:*)",
+      "Bash(gh pr view:*)",
+      "Bash(gh pr list:*)",
+      "Bash(gh pr checks:*)"
+    ]
+  }
+}

--- a/.claude/skills/petra-deck/SKILL.md
+++ b/.claude/skills/petra-deck/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: petra-deck
+description: Author or modify a petra deck (TOML lattice-KMC model) and validate it — required sections, units, gotchas, the compile/run loop. Use when creating decks, emitting deck fragments from quarry, or debugging deck compile errors.
+---
+
+# Petra deck authoring
+
+Full reference: `petra/docs/DESIGN.md`. Working examples:
+`petra/examples/kossel.toml` (tutorial), `kaolinite.toml` (the real
+thing), `kossel-etchpit.toml` (defects).
+
+## Required sections (learned the hard way)
+
+A deck does NOT compile without ALL of: `[deck]`, `[cell]` (+ sites,
+bonds), `[[species]]`, `[[kinds]]` (+ states), `[lattice]`, `[thermo]`,
+and **`[simulation]`** (steps/seed/report_every — required even if you
+only want compile-validation; its absence is the classic
+`missing field 'simulation'` error).
+
+## Units
+
+`[deck] units = "kcal/mol" | "kJ/mol" | "eV"` — applies to every
+energy-valued field (ea, dh, ds-per-K, dea tables, mu). Default
+kcal/mol. quarry emits kJ/mol and its splice guard refuses templates
+that don't declare it. Temperatures always Kelvin, prefactors 1/s.
+
+## Rates and modifiers
+
+```toml
+rate = { arrhenius = { prefactor = 1.0e13, ea = 41.84 } }
+rate = { eyring = { dh = 60.0, ds = -0.02 } }        # ΔH‡, ΔS‡/K
+
+[[reactions.modifiers]]
+select = { distance = 1, state = ["occupied"] }
+by_count = { dea = [0.0, 8.4, 16.8] }   # ΔEa by match count; last extends
+```
+
+Exactly one of constant/arrhenius/eyring; exactly one of
+per_match/by_count/when per modifier. Selectors use `Kind.state`
+qualified names or `@group` aliases.
+
+## Validate/run loop
+
+```bash
+cd petra
+cargo run -p petra-cli -- path/to/deck.toml --steps 0        # compile check
+cargo run -p petra-cli -- deck.toml --steps 10000 --seed 42 --out /tmp/run
+#   add --paranoid for differential invariant checks on new decks
+#   add --ensemble N for seed sweeps
+cargo test                                                    # includes analytic + parity gates
+```
+
+Determinism contract: same deck + seed ⇒ identical trajectory. If your
+change breaks a golden gate, the change is wrong until proven otherwise.
+
+## Gotchas
+
+- State declaration order is the `shift` ladder — reordering states
+  silently changes `shift = 1` semantics.
+- Engine runtime is canonical kcal/mol internally; deck units convert
+  once at compile. Don't "help" by pre-converting.
+- Frozen boundary sites are excluded from selectors (not fatal aborts —
+  deliberate divergence from legacy).

--- a/.claude/skills/pr-merge-gauntlet/SKILL.md
+++ b/.claude/skills/pr-merge-gauntlet/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: pr-merge-gauntlet
+description: Land a PR in this repo — auto-merge, required checks, up-to-date branch, and mandatory Sourcery thread resolution. Use whenever opening a PR here or when a PR sits OPEN/BLOCKED with green checks.
+---
+
+# Landing a PR in vsletten/dissertation
+
+Branch protection on `main`: 4 required checks (Analyze c-cpp, Analyze
+javascript-typescript, CodeQL, Sourcery review), **strict up-to-date**,
+and **required conversation resolution**. The last two cause silent
+stalls; this skill exists because they burned us (PR #12, #14).
+
+## Standard flow
+
+```bash
+gh pr create --title "..." --body "..."   # body: ## Summary / ## Test plan / ## Breaking changes
+gh pr merge --auto --squash
+```
+
+Then poll until MERGED — do not assume:
+
+```bash
+gh pr view <N> --json state,mergeStateStatus --jq '.state+" "+.mergeStateStatus'
+```
+
+## Diagnosing a stuck PR
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `BEHIND` | another PR landed first (concurrent workers are normal here) | `git fetch origin main && git merge origin/main && git push` (this box's gh lacks `pr update-branch`) |
+| `BLOCKED`, all checks green | **unresolved Sourcery threads** | see below |
+| `gh pr merge` says "base branch policy prohibits" | same | same |
+| checks "expected", not starting | CodeQL lag | wait; never hand-retry |
+
+## Sourcery threads (the one everyone forgets)
+
+List unresolved:
+
+```bash
+gh api graphql -f query='{repository(owner:"vsletten",name:"dissertation"){pullRequest(number:<N>){reviewThreads(first:40){nodes{id isResolved path line comments(first:1){nodes{body}}}}}}}' --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved|not)]'
+```
+
+Policy: **fix legitimate points** (they usually are — validate inputs,
+edge cases, tests), push, then resolve each thread:
+
+```bash
+gh api graphql -f query='mutation{resolveReviewThread(input:{threadId:"<ID>"}){thread{isResolved}}}'
+```
+
+Never resolve-without-reading to force a merge. GitHub 500s
+intermittently — retry with backoff.
+
+## House rules riding along
+
+Commits end with the Co-Authored-By line your harness specifies. If the
+PR implements a program card, it must also carry the card update +
+`docs/program/STATUS.md` line (see docs/program/PROTOCOL.md).

--- a/.claude/skills/quarry-campaign/SKILL.md
+++ b/.claude/skills/quarry-campaign/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: quarry-campaign
+description: Run a quarry QM campaign (barrier calculations, smoke tests) on the workstation — compute etiquette, logging, checkpoint/resume, failure signatures. Use before launching any qm/scripts/ campaign or long PySCF job.
+---
+
+# Running quarry campaigns
+
+Canonical driver pattern: `qm/scripts/phase1_xiao_lasaga.py`. Design
+authority `qm/SURVEY.md`; traps in `.claude/learnings/`.
+
+## Non-negotiable run rules (history: a lost 88-minute run + a wedged box)
+
+1. **Tee everything**: `... 2>&1 | tee <logfile>` — nothing may depend
+   on terminal scrollback surviving.
+2. **Thread cap**: `OMP_NUM_THREADS=16` (the box has 32; leave half).
+3. **GPU-first**: pass `--gpu` on the workstation; frequency/Hessian
+   jobs are 74× there. Only tiny test-gate molecules belong on CPU.
+4. Long jobs run backgrounded/detached with a completion signal —
+   never hold a terminal open as the only record.
+5. No multi-hour full-CPU jobs without Victor's explicit go.
+
+```bash
+cd qm && OMP_NUM_THREADS=16 uv run python scripts/phase1_xiao_lasaga.py \
+  --reaction si-neutral --gpu 2>&1 | tee /path/to/run.log
+```
+
+## Checkpoint/resume semantics
+
+Stage outputs are XYZ files in `runs/phase1/<reaction>-<xc>-<basis>-<approach>/`
+(gitignored). Existing file = stage skipped on rerun. **If you change
+scan/guess logic, delete the downstream checkpoints** (`ts_guess.xyz`,
+`ts.xyz`, `product.xyz`) or you'll resume into stale geometry. Run dirs
+are keyed by approach mode so geometries never mix.
+
+## Failure signatures (all seen live; fixes in git history)
+
+| Signature | Meaning | Response |
+|---|---|---|
+| SCF not converged at stage 1 | strained hand-built guess | pre-opt stage exists; check geometry sanity first |
+| Scan monotonic to floor (`ScanNoMaximumError`) | driven coordinate doesn't cross the ridge | mechanism problem, not numerics — needs second coordinate / different attack geometry |
+| Saddle "verified" but ΔG‡ implausibly small, soft imaginary mode | trivial rearrangement saddle | the structural gates abort these; if you see one pass, tighten gates, don't report it |
+| `r(Si-Ow)` grew ≫ guess after Sella | escaped the channel | use CI-NEB guess (already in driver) |
+| Free relax of "product" returns to reactant | intermediate isn't a minimum | construct the product deliberately (bond-breaking scan with new bonds held) |
+
+**A verified saddle is not necessarily the right saddle.** Chemistry
+gates (barrier magnitude vs literature, TS geometry) are part of
+acceptance, always.
+
+## Results discipline
+
+`results.json` + `store.sqlite` per run dir; every number carries
+method + geometry hash + date. Barriers cross tool boundaries — never
+pre-exponentiated rates (petra's gas constant differs from CODATA by
+0.17%; see learnings).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,153 @@
+# AGENTS.md
+
+This file provides guidance to Codex (Codex.ai/code) when working with code in this repository.
+
+## Repository Overview
+
+This is a dissertation project studying kaolin mineral surface reactions through Monte Carlo simulation and visualization. One model, three generations of code:
+
+1. **legacy/cpp-model/** - the dissertation-era C/C++ kinetic Monte Carlo (KMC) simulation. Historical reference and the golden standard the Rust port is verified against. The C -> C++ evolution is in this repo's history (`git log --follow legacy/cpp-model/<file>`).
+2. **legacy/viewer/** - the original React/TypeScript visualizer for simulation output. Superseded by graph-viz.
+3. **kmc-rs/** - the living Rust port (imported subtree, full history). Milestone-gated parity with the C++: dynamics bitwise-identical over 20,000 steps, full-artifact golden gate green. Also a Rust teaching codebase - see kmc-rs/docs/RUST_TOUR.md.
+4. **graph-viz/** - the visualizer overhaul (imported subtree): PGIF-native instanced property-graph viewer.
+5. **petra/** - greenfield generalization of the model: a chemistry-free lattice KMC engine where the mineral (structure, site states, TST reactions) is declared in a TOML input deck instead of code. Design doc: petra/docs/DESIGN.md. Status: P0 (design + tested skeleton).
+
+Active development happens in kmc-rs/, graph-viz/, and petra/. Treat legacy/ as read-only reference; changes there need explicit approval.
+
+## The Omnibus program (multi-agent work board)
+
+Ongoing development is organized as a card board under `docs/program/`:
+`PLAN.md` (what's ready), `PROTOCOL.md` (how to claim and deliver work —
+read before contributing), `STATUS.md` (rolling log), `cards/` (work
+items), `inbox/` (agent-to-agent messages). Program rationale:
+`docs/OMNIBUS.md`. Any agent may claim a READY card per the protocol.
+
+## Build, Test, and Development Commands
+
+### Legacy model (C++ simulation, reference)
+```bash
+cd legacy/cpp-model
+make                # Build the mckaol executable
+make clean          # Remove build artifacts
+./mckaol            # Run simulation (requires input files)
+```
+
+### Legacy viewer (superseded by graph-viz)
+```bash
+cd legacy/viewer
+npm install         # Install dependencies
+npm run dev         # Start development server at http://localhost:5173
+npm run build       # Build for production (TypeScript compilation + Vite build)
+npm run lint        # Run ESLint on TypeScript/TSX files
+npm run preview     # Preview production build
+```
+
+### kmc-rs (Rust port - the living model)
+```bash
+cd kmc-rs
+cargo build --release
+cargo test          # includes the golden parity gates against legacy/cpp-model outputs
+```
+
+### graph-viz (visualizer overhaul)
+```bash
+cd graph-viz
+npm install
+npm run dev
+npm run build
+```
+
+## Model Architecture
+
+The Monte Carlo simulation models chemical reactions at the atomic level for alumina and silica sites on mineral surfaces using a lattice-based approach.
+
+### Core Data Flow
+1. **Initialization** (mckaol.cpp:13-58): Load simulation parameters → create unit cell → build lattice → populate solid structure → terminate surface
+2. **Simulation Loop** (mckaol.cpp:61-102): For each step, generate event list → select and execute random event → update time → write output
+3. **Output** (mckaol.cpp:103-115): Write final state files (MSI, XYZ, surface analysis)
+
+For detailed model documentation, see `legacy/cpp-model/AGENTS.md`.
+
+### Key Components
+
+**Lattice System** (lattice.hpp/cpp):
+- LatticeSite stores state (100-599 encoding cation type and coordination), unit cell coordinates, neighbor list, and bond pair information
+- State encoding: first digit = site type (1=Al, 2=Si, 3=Si-O-Si, 4=Si-O-Al2, 5=Al-OH-Al), last two digits = coordination/occupancy
+- Lattice class manages 2D array of sites with periodic boundary conditions
+
+**Reaction System**:
+- ReactionList (rxnlist.hpp/cpp): Loads 28 reaction types with temperature-dependent rates from data.rxn
+- Environment (envrn.hpp/cpp): Checks local environment (next-neighbor states) for each site to determine valid reactions
+- EventList (evtlist.hpp/cpp): Linked list of possible events with specific rates based on local environment
+
+**Execution** (actions.hpp/cpp):
+- DoEvent() selects random event weighted by rate, executes state changes, returns time increment
+- 16 hydrolysis reactions (R0-R15) plus adsorption/desorption for Si and Al species
+- Reactions update site states and propagate changes to neighbors
+
+### Site State Classification
+See common.hpp:1-160 for complete scheme. Key categories:
+- 100s: Al sites (100=empty, 101-107=Al with varying OH/H2O coordination)
+- 200s: Si sites (200=empty, 201-205=Si with varying OH coordination)
+- 300s: Si-O-Si bridging oxygen sites
+- 400s: Si-O-Al2 bridging sites (most complex, 10 states)
+- 500s: Al-OH-Al bridging sites
+
+### Input Files (all in legacy/cpp-model/)
+- **data.sim**: MC steps, output frequency, random seed
+- **data.rxn**: Temperature, chemical potentials, rate constants for 28 reactions
+- **data.cell**: Unit cell atomic positions and connectivity
+- **data.lattice**: Lattice dimensions (a_cells, b_cells), surface plane orientation
+
+### Output Files
+- **start.msi, end.msi**: Cerius2 Model Structure Interface format (initial/final structures)
+- **start.xyz**: XYZ Cartesian coordinates
+- **results.dat**: Time series of site type populations
+- **surfSi.out, surfAl.out**: Surface composition analysis for Si and Al sites
+- **stepN.msi**: Optional intermediate snapshots at intervals
+
+## Viewer Architecture
+
+React application using Three.js (via @react-three/fiber) to render molecular structures from simulation output files.
+
+### Core Components
+
+**FileUploader** (components/FileUploader.tsx): Accepts .msi, .car, .pdb, .xyz files via drag-and-drop or file picker
+
+**MoleculeViewer** (components/MoleculeViewer.tsx): Three.js scene with interactive camera controls (orbit, zoom, pan), renders atoms as spheres and bonds as cylinders
+
+**ModelInfo** (components/ModelInfo.tsx): Displays structure statistics, element counts, atom/bond information
+
+### Data Pipeline
+1. User uploads file → FileUploader reads content
+2. App.tsx calls cerius2Parser.parseModelFile()
+3. Parser extracts atoms (id, element, position, label, charge) and bonds (from, to)
+4. Data passed to MoleculeViewer for 3D rendering
+5. ModelInfo displays structural metadata
+
+### File Format Support
+Parser handles Cerius2 .msi files (see msi-schema.md for format details). The MSI format uses keyword-value pairs with sections like (1 Atom), (1 Bond) for defining molecular structure.
+
+### Styling
+Element colors defined in utils/elementColors.ts, supports charge-based and element-based coloring schemes
+
+## Development Notes
+
+### Model
+- Uses C++11 standard with aggressive optimization (-O3 -ffast-math) in production builds
+- Comment out optimization and add -ggdb in Makefile for debugging
+- Breadth-first search (bfsearch.hpp/cpp) used to identify and remove unattached atomic clusters
+- Random number generation via ran2.cpp (Numerical Recipes algorithm)
+
+### Viewer
+- Uses Vite for fast development and optimized builds
+- TypeScript strict mode enabled
+- React 19 with functional components and hooks
+- Three.js r174+ with @react-three/fiber for declarative 3D
+- No tests currently configured (npm test will fail)
+
+### Code Style (from viewer/AGENTS.md)
+- Imports: Group as (1) React/framework (2) External libraries (3) Internal modules
+- TypeScript: Prefer interfaces over types, explicit return types on functions
+- Naming: camelCase for variables/functions, PascalCase for classes/components
+- Use Prettier defaults for formatting

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,7 +129,7 @@ React application using Three.js (via @react-three/fiber) to render molecular st
 Parser handles Cerius2 .msi files (see msi-schema.md for format details). The MSI format uses keyword-value pairs with sections like (1 Atom), (1 Bond) for defining molecular structure.
 
 ### Styling
-Element colors defined in utils/elementColors.ts, supports charge-based and element-based coloring schemes
+Element colors are defined in utils/elementColors.ts and support charge-based and element-based coloring schemes.
 
 ## Development Notes
 


### PR DESCRIPTION
## Summary
The cold-agent kit for the program board, closing three gaps found while building it:

- **AGENTS.md was untracked** — Codex-style agents cloning the repo got no entry point. Now committed, with the program-board section.
- **Three thin repo skills** (`.claude/skills/`) that make recurring *procedures* executable while pointing at canonical docs for substance: `pr-merge-gauntlet` (why PRs sit BLOCKED with green checks + the Sourcery GraphQL resolution flow), `quarry-campaign` (compute etiquette, tee/checkpoint/resume semantics, the five failure signatures from the live Phase-1 TS hunt), `petra-deck` (required sections including the non-obvious `[simulation]`, units rules, modifier shapes, the validate loop).
- **`.claude/settings.json`** permission allowlist for the standard gates (cargo/uv test+lint, read-only git/gh) so fleet workers don't stall on prompts.

Deliberately thin: skills carry commands and diagnosis tables, not duplicated design docs — single source of truth stays in docs/ and petra/qm docs.

## Test plan
Docs/config only. Skill frontmatter follows the standard SKILL.md format; settings.json is valid JSON (checked).

## Breaking changes
None. The allowlist only adds permissions; nothing is denied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Equip repository agents with committed guidance, repeatable domain workflows, and the permissions needed to operate without routine prompts.

New Features:
- Add repository-level agent guidance covering the project structure, program board, development commands, and model architecture.
- Add reusable skills for PR merging, quarry QM campaigns, and Petra deck authoring and validation.

Enhancements:
- Provide documented operational workflows and troubleshooting guidance for common agent tasks.
- Add a Claude permission allowlist for standard testing, linting, and read-only repository operations.

Documentation:
- Commit AGENTS.md as the repository entry point for Codex-style agents.