### PR TITLE
docs: correct agent kit references and Petra guidance

### DIFF
--- a/.claude/skills/petra-deck/SKILL.md
+++ b/.claude/skills/petra-deck/SKILL.md
@@ -11,11 +11,13 @@ thing), `kossel-etchpit.toml` (defects).
 
 ## Required sections (learned the hard way)
 
-A deck does NOT compile without ALL of: `[deck]`, `[cell]` (+ sites,
-bonds), `[[species]]`, `[[kinds]]` (+ states), `[lattice]`, `[thermo]`,
-and **`[simulation]`** (steps/seed/report_every — required even if you
-only want compile-validation; its absence is the classic
-`missing field 'simulation'` error).
+A deck does NOT compile without `[deck]`, `[cell]` (with sites),
+`[[kinds]]` (with states), `[lattice]`, `[thermo]`, and
+**`[simulation]`** (`steps` and `seed`; `report_every` is optional).
+`[[species]]` is required when a state has a non-`vacant` occupant;
+`[[cell.bonds]]` is optional for models with no connectivity. A missing
+`[simulation]` section is the classic `missing field 'simulation'`
+error, even when you only want compile-validation.
 
 ## Units
 
@@ -59,5 +61,6 @@ change breaks a golden gate, the change is wrong until proven otherwise.
   silently changes `shift = 1` semantics.
 - Engine runtime is canonical kcal/mol internally; deck units convert
   once at compile. Don't "help" by pre-converting.
-- Frozen boundary sites are excluded from selectors (not fatal aborts —
-  deliberate divergence from legacy).
+- Frozen boundary sites remain visible to selectors unless the selector
+  sets `frozen = false`; use the filter deliberately (Petra does not use
+  the legacy fatal-abort behavior).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,7 +66,7 @@ The Monte Carlo simulation models chemical reactions at the atomic level for alu
 2. **Simulation Loop** (mckaol.cpp:61-102): For each step, generate event list → select and execute random event → update time → write output
 3. **Output** (mckaol.cpp:103-115): Write final state files (MSI, XYZ, surface analysis)
 
-For detailed model documentation, see `legacy/cpp-model/AGENTS.md`.
+For detailed model documentation, see `legacy/cpp-model/CLAUDE.md`.
 
 ### Key Components
 
@@ -126,7 +126,7 @@ React application using Three.js (via @react-three/fiber) to render molecular st
 5. ModelInfo displays structural metadata
 
 ### File Format Support
-Parser handles Cerius2 .msi files (see msi-schema.md for format details). The MSI format uses keyword-value pairs with sections like (1 Atom), (1 Bond) for defining molecular structure.
+Parser handles Cerius2 .msi files (see `legacy/viewer/msi-schema.md` for format details). The MSI format uses keyword-value pairs with sections like (1 Atom), (1 Bond) for defining molecular structure.
 
 ### Styling
 Element colors are defined in utils/elementColors.ts and support charge-based and element-based coloring schemes.
@@ -146,7 +146,7 @@ Element colors are defined in utils/elementColors.ts and support charge-based an
 - Three.js r174+ with @react-three/fiber for declarative 3D
 - No tests currently configured (npm test will fail)
 
-### Code Style (from viewer/AGENTS.md)
+### Code Style (from `legacy/viewer/CLAUDE.md`)
 - Imports: Group as (1) React/framework (2) External libraries (3) Internal modules
 - TypeScript: Prefer interfaces over types, explicit return types on functions
 - Naming: camelCase for variables/functions, PascalCase for classes/components


### PR DESCRIPTION
## Summary

Follow-up to #23 after the original PR merged during the automated review.

- replace stale AGENTS.md references with tracked CLAUDE.md paths
- make the viewer schema reference repository-root-relative
- align the Petra deck skill with the implemented optional fields and frozen-selector semantics

## Test plan

- Parsed `.claude/settings.json` with Python JSON tooling
- Validated each skill has `name` and `description` frontmatter
- Verified every referenced repository path exists
- Ran `git diff --check`

Local Petra execution was not run because Cargo is unavailable on the PR-watcher host; repository CI remains authoritative.

## Breaking changes

None.

## Summary by Sourcery

Update repository guidance and documentation references to match the current project structure and Petra deck behavior.

Bug Fixes:
- Correct stale repository documentation links and references to use tracked CLAUDE.md paths and a repository-root-relative viewer schema path.

Enhancements:
- Align Petra deck guidance with current optional species and bond sections, required simulation fields, and frozen-selector behavior.