### PR TITLE
docs: card A7-kinetics-database — machine-readable kinetics compilation groundwork

### DIFF
--- a/docs/program/PLAN.md
+++ b/docs/program/PLAN.md
@@ -28,6 +28,7 @@ on main). Priority P0 > P1 > P2 within READY.
 | [B1-schema-rfc](cards/B1-schema-rfc.md) | B | P0 | any | done | — |
 | [D2a-astro-rate-reproduction](cards/D2a-astro-rate-reproduction.md) | D | P1 | workstation | ready | — |
 | [A1b-acid-mechanisms](cards/A1b-acid-mechanisms.md) | A | P1 | workstation | ready | — |
+| [A7-kinetics-database](cards/A7-kinetics-database.md) | A | P2 | any | ready | — |
 | [A2-production-energetics](cards/A2-production-energetics.md) | A | P1 | workstation | blocked: ORCA install (Victor) + A1b | A1b |
 | [B2-engine-refactor](cards/B2-engine-refactor.md) | B | P0 | any | blocked: Victor review ack of RFC-001 | B1 |
 | [B3-conformance-decks](cards/B3-conformance-decks.md) | B | P1 | any | blocked: B2 | B2 |

--- a/docs/program/STATUS.md
+++ b/docs/program/STATUS.md
@@ -9,6 +9,10 @@ Deviations get a `DEVIATION:` note; details live in the card.*
   trait + v1 compat shim + determinism/RNG contract + B2/B3 test plan;
   corrosion + ice-mantle showcase fragments). B2 unblocked pending Victor's
   review ack of the RFC.
+- 2026-08-18 — fable — Card A7-kinetics-database added (machine:any,
+  macbot-shaped): schema + extraction groundwork for a machine-readable
+  successor to Palandri & Kharaka 2004. Pointer task queued in
+  mission-control for laptop workers.
 - 2026-08-18 — fable — Program tracking system created (PLAN, PROTOCOL,
   STATUS, 10 seed cards, inbox). Board opens with B1-schema-rfc as the
   keystone READY card.

--- a/docs/program/cards/A7-kinetics-database.md
+++ b/docs/program/cards/A7-kinetics-database.md
@@ -1,0 +1,64 @@
+# A7-kinetics-database — machine-readable dissolution-kinetics compilation, v0
+
+- status: ready
+- track: A (geochemistry, community-infrastructure lane)
+- priority: P2
+- machine: any (laptop-shaped by design: reading, extraction, structuring — no GPU, no long compute)
+- depends: —
+- claimed-by: (see agents/A7-kinetics-database branch)
+
+## Objective
+
+Groundwork for a modern successor to Palandri & Kharaka (2004), *A
+compilation of rate parameters of water-mineral interaction kinetics for
+application to geochemical modeling* (USGS Open-File Report 2004-1068) —
+still the field's standard rate compilation, 20+ years stale, and not
+machine-readable. This card is v0: schema + the core extraction.
+
+1. **Schema v0**: define the record format (TOML, one file per mineral)
+   in `kinetics-db/SCHEMA.md`. Required fields: mineral name + formula;
+   per-mechanism (acid/neutral/base) log k25, Ea, reaction orders (n_H+,
+   n_OH-, others); rate-law form; surface-area normalization basis
+   (BET vs geometric — record which, this is the classic comparability
+   trap); provenance (source, page/table, year); uncertainty fields
+   (even if initially empty — the schema must carry them so later UQ
+   work has a home); free-text caveats.
+2. **Extract P&K's silicate core**: the phyllosilicates (kaolinite
+   first), feldspars, quartz/silica polymorphs, and olivine/pyroxene
+   groups — target ≥25 minerals — into `kinetics-db/minerals/*.toml`
+   per the schema, each value carrying its P&K table/page provenance.
+   (Full P&K coverage + carbonates → follow-up card.)
+3. **Source inventory 2004→present**: `kinetics-db/SOURCES.md` — a
+   candidate list (~30–50 entries, DOIs) of primary rate studies and
+   compilations published since P&K, one line each on what they'd add.
+   Include the obvious anchors: Ganor/Cama kaolinite work, Brantley
+   group compilations, Hermanska et al. 2022-23 (the recent
+   thermodynamic-consistency compilation — check scope overlap
+   honestly), ERW-driven olivine/wollastonite studies.
+4. **A tiny validator**: `kinetics-db/validate.py` (stdlib tomllib
+   only) that checks every mineral file parses and carries required
+   fields; wire as a runnable check documented in SCHEMA.md.
+
+## Context
+
+- docs/OMNIBUS.md Track A; the ideation lineage: this is the
+  "community infrastructure" play — unglamorous, citable, and the
+  natural calibration substrate for the field-lab discrepancy flagship
+  (docs/scoping/field-lab-discrepancy.md needs exactly these rates for
+  its validation gates).
+- P&K 2004-1068 is a public USGS document (pubs.usgs.gov). Extraction
+  is transcription with provenance, not judgment — flag ambiguities in
+  caveats rather than resolving them silently.
+
+## Acceptance
+
+- `kinetics-db/SCHEMA.md`, `SOURCES.md`, `validate.py` exist on main;
+  ≥25 mineral TOML files parse clean under the validator; every numeric
+  value has provenance; kaolinite record cross-checked against the
+  experimental Ea range quoted in qm/SURVEY.md §7.3 (29 kJ/mol acidic /
+  33–51 alkaline) with any discrepancy noted in caveats.
+- STATUS.md line + this card updated in the delivering PR (protocol).
+
+## Progress
+
+- 2026-08-18 — card created (fable), macbot-targeted by design.

--- a/docs/program/cards/A7-kinetics-database.md
+++ b/docs/program/cards/A7-kinetics-database.md
@@ -53,7 +53,7 @@ machine-readable. This card is v0: schema + the core extraction.
 ## Acceptance
 
 - `kinetics-db/SCHEMA.md`, `SOURCES.md`, `validate.py` exist on main;
-  ≥25 mineral TOML files parse clean under the validator; every numeric
+  ≥25 mineral TOML files parse cleanly under the validator; every numeric
   value has provenance; kaolinite record cross-checked against the
   experimental Ea range quoted in qm/SURVEY.md §7.3 (29 kJ/mol acidic /
   33–51 alkaline) with any discrepancy noted in caveats.


### PR DESCRIPTION
## Summary
New READY board card, deliberately laptop-shaped for the idle macbots: schema + core extraction groundwork for a machine-readable successor to Palandri & Kharaka (2004) — the field's standard dissolution-rate compilation, 20+ years stale and PDF-bound. Scope: TOML schema with provenance + UQ fields, ≥25 silicate minerals extracted with per-value provenance, a 2004→present source inventory, and a stdlib validator. Feeds the field-lab discrepancy flagship's validation gates. PLAN row + STATUS line included per protocol.

## Test plan
Docs only (the card's own acceptance includes the validator, delivered by whoever works it).

## Breaking changes
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Establish the A7 kinetics-database workstream for building a provenance-rich, machine-readable dissolution-kinetics compilation.

Enhancements:
- Add a ready-to-claim A7 card defining groundwork for a machine-readable successor to the Palandri & Kharaka dissolution-kinetics compilation, including schema, provenance and uncertainty requirements, mineral extraction, source inventory, and validation tooling.
- Document the planned extraction scope, acceptance criteria, dependencies, and contribution context for the kinetics database work.

Documentation:
- Register the A7 kinetics-database card in the program plan and status tracking.