### PR TITLE
docs: qm/HANDOFF.md Phase-2 edition + READY card A3-barrier-ladder

### DIFF
--- a/docs/program/PLAN.md
+++ b/docs/program/PLAN.md
@@ -28,6 +28,7 @@ on main). Priority P0 > P1 > P2 within READY.
 | [B1-schema-rfc](cards/B1-schema-rfc.md) | B | P0 | any | done | — |
 | [D2a-astro-rate-reproduction](cards/D2a-astro-rate-reproduction.md) | D | P1 | workstation | ready | — |
 | [A1b-acid-mechanisms](cards/A1b-acid-mechanisms.md) | A | P1 | workstation | ready | — |
+| [A3-barrier-ladder](cards/A3-barrier-ladder.md) | A | P1 | workstation | ready | — |
 | [A7-kinetics-database](cards/A7-kinetics-database.md) | A | P2 | any | done | — |
 | [A2-production-energetics](cards/A2-production-energetics.md) | A | P1 | workstation | blocked: ORCA install (Victor) + A1b | A1b |
 | [B2-engine-refactor](cards/B2-engine-refactor.md) | B | P0 | any | blocked: Victor review ack of RFC-001 | B1 |

--- a/docs/program/STATUS.md
+++ b/docs/program/STATUS.md
@@ -31,3 +31,7 @@ Deviations get a `DEVIATION:` note; details live in the card.*
 - 2026-08-18 — fable — Phase 0 closed: quarry package (PR #12), smoke
   v2 (PR #14); measured 4090: 74× analytic Hessians vs 32-thread CPU,
   identical energies. GPU owns all frequency work.
+- 2026-08-19 — fable — qm/HANDOFF.md rewritten as the Phase-2 edition
+  (barrier-ladder build plan: crystallographic cluster builder from the
+  kaolinite deck cell, per-cell campaign driver, by_count emission,
+  CALC-002..005 closure); new READY card A3-barrier-ladder.

--- a/docs/program/cards/A3-barrier-ladder.md
+++ b/docs/program/cards/A3-barrier-ladder.md
@@ -1,0 +1,44 @@
+# A3-barrier-ladder — connectivity × protonation barrier ladder (Phase 2)
+
+- status: ready
+- track: A (geochemistry)
+- priority: P1
+- machine: workstation (GPU campaigns; cluster-builder code is machine-any)
+- depends: — (runs at the validated b3lyp/def2-svp/df tier; A2 re-tiers
+  the finished ladder later; acid-state variants may reuse A1b's
+  protonated-bridge machinery when it lands but are not blocked by it)
+- claimed-by:
+
+## Objective
+Execute qm/HANDOFF.md (Phase 2 edition — the full build plan lives
+there): build the crystallographic cluster builder (terminated,
+peripherally-frozen edge clusters cut from the kaolinite cell in
+petra/examples/kaolinite.toml, per KMC site family and protonation
+state), generalize the Phase-1 driver into a per-ladder-cell campaign
+script, compute the connectivity- and protonation-resolved barriers for
+the five site families, and emit them as petra `by_count`/`when` tables
+with provenance. Closes CALCULATIONS.md rows CALC-002..005 from
+`needed` to `computed`.
+
+## Context
+- qm/HANDOFF.md — the complete Phase-2 plan (read first)
+- qm/SURVEY.md §6.2 (cluster norms), §7.3 (pKa table, kaolinite targets)
+- qm/CALCULATIONS.md CALC-002..005 (the shopping list)
+- Repo skills: quarry-campaign, petra-deck, pr-merge-gauntlet
+- Reference result: si-neutral 113.05 kJ/mol (27.0 kcal/mol) in the
+  claude/qm-phase1-scan-extend worktree runs/ dir
+- .claude/learnings/ — the measured TS-hunt failure modes and gates
+
+## Acceptance
+- Cluster-builder unit gates green (CPU-only): taxonomy match against
+  the deck cell, termination/charge bookkeeping, frozen shell
+  peripheral, no collisions.
+- Pilot cell (300s Si–O–Si, neutral, reference connectivity) reproduces
+  the si-neutral barrier modulo a logged lattice-resistance shift.
+- Per completed family: gated barriers in runs/ + store, an emitted
+  petra fragment that compiles via petra-cli round-trip, and the
+  CALCULATIONS.md row updated — one PR per family.
+- Full fast test suite + ruff green on every PR.
+
+## Progress
+- 2026-08-19 — card created with the Phase-2 handoff rewrite (fable).

--- a/qm/HANDOFF.md
+++ b/qm/HANDOFF.md
@@ -1,146 +1,179 @@
-# QM lab session handoff — standing up the barrier pipeline
+# QM lab session handoff — Phase 2: the barrier ladder
 
-*Written 2026-08-18 for a fresh session. The design authority is
-`qm/SURVEY.md` (read it in full — it is the survey AND the recommendation);
-this handoff adds the build plan, house conventions, and what changed since
-the survey was written (Petra exists now).*
+*Written 2026-08-19 for a fresh session. Second edition — the Phase 0/1
+handoff (build plan for the quarry platform itself) is in git history at
+this path. Design authority remains `qm/SURVEY.md` (read §6–§8 at
+minimum); the work ledger is `qm/CALCULATIONS.md` (CALC-002..005 are this
+phase); the claimable card is `docs/program/cards/A3-barrier-ladder.md`
+(claim per `docs/program/PROTOCOL.md` before starting).*
 
 ## 0. Mission
 
-Build the thin platform the survey's §8 says is "genuinely ours to build":
-the orchestration layer that turns mineral crystallography + a reaction
-taxonomy into **site-resolved activation energies and rate constants**,
-computed on the recommended free stack, and emitted in the formats our KMC
-consumes. Everything heavy (DFT engines, TS optimizers, thermochemistry) is
-assembled, not written — see SURVEY.md §8's verdict and §2–§5 for exactly
-which packages and why.
+Compute the **connectivity- and protonation-resolved barrier ladder** for
+the five KMC site families (100s Al, 200s Si, 300s Si–O–Si, 400s
+Si–O–Al₂, 500s Al–OH–Al) on terminated, constrained cluster models cut
+from kaolinite crystallography, and emit them as petra `by_count`/`when`
+ΔEa tables with per-number provenance. This is the scientific payload the
+whole platform was built for: the *non-flat environment tables the legacy
+model never had* (its `data.rxn` gives every environment variant of a
+reaction the same number).
 
-The stack, one line each (details + versions in SURVEY.md TL;DR table):
-PySCF + GPU4PySCF (workhorse DFT, analytic Hessians, SMD), ORCA 6
-(cross-check + DLPNO-CCSD(T) calibration; free but closed, registration,
-**no redistribution** — never commit or containerize it), geomeTRIC + Sella
-(TS/IRC), xtb + CREST (screening), quasi-RRHO + Eyring/tunneling (own the
-~50-line module; GoodVibes/Arkane as audited references), ASE + plain
-Python + SQLite as glue. No AiiDA/pyiron — one user, one box.
+## 1. State of the world (what already works — do not rebuild)
 
-## 1. Hardware reality — read before running anything
+**Phase 0 + 1 are done and merged** (PRs #12–#19, more in flight):
 
-SURVEY.md targets **Victor's workstation**: Ryzen 9 7950X (16C/32T), 64 GB
-DDR5, RTX 4090 24 GB. Two consequences for a session:
+- `quarry/` package: pipeline (PySCF energy/gradient/opt/freq, GPU via
+  `DftSettings(use_gpu=True, density_fit=True)`), rates (quasi-RRHO →
+  Eyring + Wigner/Eckart), emit (petra fragments + data.rxn), store
+  (SQLite provenance), ts.py (Sella saddle search, verify, quick-IRC,
+  auto-extending constrained scans with spike repair, CI-NEB guess).
+- **First validated barrier**: si-neutral (H₂O + (HO)₃Si–O–Si(OH)₃,
+  4-center concerted TS) — **ΔG‡(298) = 113.05 kJ/mol = 27.0 kcal/mol**
+  at b3lyp/def2-svp/df vs Xiao & Lasaga ~29. TS: r(Si–Ow)=1.73,
+  r(Si–Obr)=1.97, proton delivered, one imaginary mode (100i).
+  Artifacts: `runs/phase1/si-neutral-b3lyp-def2-svp-flank/` in the
+  `claude/qm-phase1-scan-extend` worktree (results.json, store.sqlite).
+- **Measured hardware economics** (Phase 0): 4090 does analytic DF
+  Hessians ~74× faster than the 32-thread CPU; gradients ~2–3 s at
+  ~20 atoms/def2-svp. One barrier ≈ 45–90 min GPU wall. Frequency-heavy
+  work ALWAYS runs on the GPU.
+- **al-neutral is in flight, not yours**: fleet workers found it goes
+  through a *sequential* mechanism (associative pentacoordinate
+  intermediate, then bridge rupture — two saddles, rate-limiting step
+  wins) — see TASK-168 in mission-control queue and dissertation PR #29.
+  Do not duplicate; the mechanism lesson matters for the ladder though:
+  **Si–O–Al chemistry may be stepwise where Si–O–Si is concerted.**
+- Parallel cards on the board: `A1b-acid-mechanisms` (protonated-bridge
+  path for si-acid/al-acid — READY, may be claimed by someone else) and
+  `A2-production-energetics` (r²SCAN-3c / ωB97M-V/def2-TZVPD + SMD +
+  DLPNO calibration — BLOCKED on Victor's ORCA install). Phase 2 runs at
+  the validated b3lyp/def2-svp/df tier; A2 re-tiers the ladder later.
+  Design every result file so re-tiering is a settings swap, not a redo.
 
-1. **A cloud session container is not that machine.** Detect what you're on
-   before making performance claims. All *code* (cluster builder, pipeline,
-   parsers, rate module, tests) develops and tests fine anywhere on small
-   molecules with CPU PySCF. The GPU smoke test and real benchmarks
-   (SURVEY.md §9 Phase 0) only mean something on Victor's box — structure
-   the work so he can run one script there and paste results back.
-2. The 4090's FP64 is capped (~1.3 TFLOPS ≈ the CPU's peak): expect
-   **2–5× (SCF/gradients) and 5–10× (Hessians)** over the 16 cores, not
-   datacenter numbers. Frequency jobs dominate TST cost, so that is still
-   the win that matters. Test the cuEST INT8-emulation path empirically
-   (`nvidia-cuest-cu12`, already integrated in GPU4PySCF) — no published
-   4090 numbers exist; ours would be genuinely informative. Details §3.
+**Read before running anything**: the three repo skills —
+`quarry-campaign` (compute etiquette: tee everything, OMP cap 16,
+GPU-first, checkpoint/resume, the failure signatures we already hit),
+`pr-merge-gauntlet` (cloud Hermes owns the PR lifecycle now — open the
+PR and stand down; `human-merge` label to hold), `petra-deck` (deck
+authoring/validation for the emission step). Also
+`.claude/learnings/` (debugging.md: the five TS-hunt traps, each
+measured live; gotchas.md; performance.md).
 
-## 2. What changed since the survey: Petra
+## 2. What Phase 2 actually builds
 
-The survey predates Petra (`petra/` — read `petra/docs/DESIGN.md` §1–§4 for
-orientation). Its §8.3 "bridge" targeted regenerating kmc-rs's `data.rxn`.
-That is still worth doing (Phase 3 validation against the dissertation),
-but **the primary output target is now a Petra deck fragment**: TOML
-`[[reactions]]` entries with Arrhenius/Eyring parameters, plus `by_count`
-ΔEa tables for connectivity dependence — i.e. the *non-flat environment
-tables the legacy model never had*. The kaolinite deck's reaction taxonomy
-(`petra/examples/kaolinite.toml`, states documented in its header) is the
-exact shopping list of barriers: Si–O–Si, Si–O–Al (both sides), Al–OH–Al
-hydrolysis ± protonation state, plus Si/Al attachment/detachment. Petra's
-per-deck units (kcal/mol, kJ/mol, eV) mean no unit gymnastics at the
-boundary — emit kJ/mol and say so.
+Two genuinely new pieces, then a big campaign:
 
-## 3. Proposed shape (adjust freely, but start here)
+### 2a. Crystallographic cluster builder (`quarry/clusters.py` extension)
 
-New Python package in `qm/` — suggested name **`quarry`** (the place stone
-comes from; petra is the rock). House rules from `.claude/CLAUDE.md`:
-Python 3.13, **uv** for env/deps, ruff, tests for all new functions.
+Phase 1 used hand-built dimers. Phase 2 cuts clusters from the real
+mineral. **The crystallography is already machine-readable**:
+`petra/examples/kaolinite.toml` `[cell]` carries the 26-site unit cell
+(fractional coords, cell parameters, full bond list with `dcell` image
+offsets, site kinds matching the five families) — parse it with stdlib
+`tomllib`; cross-check against `legacy/cpp-model/data.cell`. Build:
 
-```
-qm/
-  SURVEY.md            (the design authority — do not fork its content)
-  HANDOFF.md           (this file)
-  pyproject.toml       (uv-managed; deps: pyscf, geometric, sella, ase,
-                        goodvibes, numpy; gpu4pyscf-cuda12x + nvidia-cuest
-                        as an optional [gpu] extra; xtb via conda-forge or
-                        binary — document, don't vendor)
-  quarry/
-    clusters.py        cluster builder: terminated, constrained
-                       aluminosilicate clusters per KMC site family
-                       (100s–500s) and protonation state; peripheral-atom
-                       constraints for lattice resistance (survey §6.2)
-    pipeline.py        the tiered protocol as composable steps:
-                       xtb screen → r²SCAN-3c (or B3LYP-D4/def2-TZVP)
-                       opt+freq → geomeTRIC/Sella TS + IRC verify →
-                       ωB97M-V/def2-TZVPD + SMD single points
-    rates.py           quasi-RRHO ΔG‡ → Eyring k(T) with Wigner/Eckart
-                       tunneling (the in-house ~50 lines, gated against
-                       GoodVibes/Arkane numbers)
-    emit.py            Petra deck fragments + legacy data.rxn, each number
-                       with provenance (method, geometry hash, date)
-    store.py           SQLite of structures/jobs/results (survey §4.3)
-  scripts/
-    phase0_smoke.py    env + engine sanity, CPU vs GPU timings table
-                       (B3LYP/def2-TZVP E+grad+Hessian on Si(OH)₄·nH₂O) —
-                       the script Victor runs on the 4090 box
-  tests/               fast, CPU-only, tiny molecules (H₂O, Si(OH)₄ at
-                       small basis): pipeline mechanics, rate math vs hand
-                       Eyring values, emit round-trips into petra's parser
-```
+- `from_deck_cell(deck_path, site_kind, ...)`: replicate the cell,
+  pick a center site of the requested family at an edge, walk the bond
+  graph to a cutoff (aim 8–20 tetrahedral/octahedral centers, 50–150
+  atoms — SURVEY §6.2 norms), terminate dangling bonds with OH/H₂O
+  (survey's termination rules), and mark the outer shell as
+  `frozen_indices` (lattice resistance is physics, not a detail:
+  Pelmenschikov's +5–16 kcal/mol vs free clusters). The frozen-atom
+  contract already flows through optimize/scans/Sella/NEB untouched.
+- Charge/protonation assignment per the pKa table (SURVEY §7.3):
+  Si–OH ≈ 6.9, Al–OH₂OH ≈ 5.7, bridging Si–O ≈ 2, octahedral
+  Al–OH₂ ≈ 10. For each family compute the states that matter across
+  pH 2–10 (typically neutral + one protonated or deprotonated variant).
+- Gates: stoichiometry/charge bookkeeping, no atom collisions, frozen
+  shell actually peripheral, cluster matches the deck's site taxonomy.
+  All testable CPU-only without DFT.
 
-Testing philosophy mirrors petra's gates: the rate module is checked
-against closed-form Eyring numbers to 1e-12; `emit.py` output must be
-*compiled by petra-deck* in a test (add a dev workflow that runs
-`cargo run -p petra-cli -- <emitted deck> --steps 0` or parse via a tiny
-Rust test — cheapest is emitting into a template deck and invoking the
-petra CLI, which exists in-repo).
+### 2b. Ladder campaign driver (`scripts/phase2_ladder.py`)
 
-## 4. Phase plan (from SURVEY.md §9, operationalized)
+Generalize the Phase-1 driver from "one reaction" to "one (family,
+connectivity n, protonation state) cell of the ladder":
 
-- **Phase 0 — bootstrap** (this session): package skeleton, uv env, CPU
-  smoke tests green in-session; `scripts/phase0_smoke.py` ready for
-  Victor's box (GPU optional-detect, prints the timing table). Deliver via
-  PR (see §5).
-- **Phase 1 — Xiao & Lasaga reproduction**: (HO)₃Si–O–Si(OH)₃ and
-  (HO)₃Si–O–Al(OH)₃⁻ + H₂O/H₃O⁺ hydrolysis barriers; compare 1990s numbers
-  (§7.1: ~24 kcal/mol acid, ~19 base) and modern values. In-session at
-  modest basis; production numbers on the workstation. This validates every
-  stack layer at once.
-- **Phase 2 — the barrier ladder**: connectivity × protonation resolved
-  barriers for the five KMC site families (survey §6.2/§7.3 for cluster
-  norms and the pKa table that sets protonation states worth computing).
-  ORCA DLPNO-CCSD(T) spot calibration (workstation only).
-- **Phase 3 — close the loop**: emit the Petra kaolinite deck's rates
-  (+ regenerate `data.rxn`), run both engines, compare against experimental
-  Ea (kaolinite ~29 kJ/mol acidic, 33–51 alkaline; quartz 66–90 — §7.3).
+- Reuse the whole proven stage machinery (pre-opt → opt → approach scan
+  → proton scan → product construction → CI-NEB → Sella → in-channel +
+  escaped-saddle gates → verify → quick-IRC → quasi-RRHO). It is all
+  importable; the driver mostly supplies geometry and bookkeeping.
+- Connectivity dimension: for the target bridge/site, vary the number of
+  intact neighbors n by cutting clusters around sites with different
+  coordination (edge vs kink vs terrace analogs). Each n is one ladder
+  cell → one `dea[n]` entry.
+- Every cell writes `runs/phase2/<family>-<state>-n<count>/` with
+  checkpoints, results.json, store.sqlite — resumable, batchable.
+  Expected failure modes and their signatures are in
+  `.claude/learnings/debugging.md`; the gates abort loudly rather than
+  report plausible-wrong numbers. Sequential (two-saddle) mechanisms
+  are legitimate outcomes — record both saddles, report the
+  rate-limiting ΔG‡ (the al-neutral lesson).
 
-## 5. House workflow (Victor's standing instructions)
+### 2c. Emission + ledger closure
 
-- Branch `claude/<topic>-<suffix>`; every push ends in a **PR to `main`,
-  merged** — enable auto-merge (branch protection wants 4 CodeQL checks
-  that lag and read "expected"; don't hand-retry). After merge,
-  **sync local `main`** (`git fetch origin main:main`). GitHub 500s
-  intermittently; retry with backoff.
-- ORCA: registration-gated, no redistribution — install instructions in a
-  README, never the binary in git. Same for any gated ML weights (UMA).
-  License flags table: SURVEY.md Appendix A.
-- Big outputs (checkpoints, cube files) stay out of git; the SQLite store
-  keeps derived numbers + provenance, structures as light XYZ.
+- For each reaction family: baseline barrier at the reference
+  connectivity → petra `rate = {eyring = ...}`; ΔEa(n) relative to
+  baseline → `by_count = {dea = [...]}` tables; protonation variants →
+  separate `[[reactions]]` entries gated by `when`/state vocabulary
+  (state names documented in the kaolinite deck header). Emit with
+  `quarry.emit` (provenance comments are mandatory — method, geometry
+  hash, date); splice-test against the template and compile with
+  petra-cli (the round-trip test pattern exists; `petra-deck` skill).
+- Update `qm/CALCULATIONS.md` rows CALC-002..005 (`needed` → `computed`
+  with the value/provenance pointer) in the same PR as each batch of
+  numbers — invariant: merged means ledger updated.
+- Regenerating legacy `data.rxn` stays Phase 3 (needs the full 28-slot
+  table); don't block the ladder on it.
 
-## 6. Traps the survey already identified (don't rediscover)
+## 3. Suggested execution order
 
-- Psi4: no SMD + finite-difference DFT Hessians — third opinion only.
-- MLIPs: fine for guesses/conformers; **DFT owns every number that enters
-  KMC**; non-conservative variants have broken Hessians (§5).
-- Pure continuum solvation is qualitatively wrong for water-mediated
-  hydrolysis — cluster-continuum with 3–6 explicit waters (§6.3).
-- Free clusters underestimate lattice resistance by up to tens of kJ/mol —
-  constraint strategy is physics, not a detail (§6.2, Pelmenschikov).
-- pysisyphus unmaintained (pin, don't build on); AIMNet2 has no Al;
-  geomeTRIC's BSD has a no-AI-training-data clause (fine for our use).
+1. Claim `A3-barrier-ladder` per PROTOCOL (branch push = atomic claim),
+   worktree `agents/A3-barrier-ladder`.
+2. Build + gate the crystallographic cluster builder (CPU-only tests;
+   this is the bulk of the new code). PR early if it stands alone.
+3. Pilot ONE ladder cell end-to-end on the GPU: Si–O–Si bridge (300s),
+   neutral, reference connectivity — should reproduce si-neutral's
+   113 kJ/mol within the cluster-size effect (expect a shift UP from
+   lattice resistance; that shift is itself a publishable observable —
+   log it prominently).
+4. Then batch: one family per overnight campaign (~5–10 cells each,
+   ~1 h/cell GPU). Order by KMC impact: 400s Si–O–Al₂ (the kaolinite
+   deck's biggest family) → 300s → 500s Al–OH–Al → attachment/
+   detachment ladders (CALC-005, these are minima-only — no TS hunt,
+   much cheaper) → 100s/200s adsorption sites.
+5. Emit + ledger PR per completed family, not one giant PR at the end.
+
+## 4. Hard rules (unchanged, learned the hard way)
+
+- **Compute etiquette**: everything tee'd to files (never trust terminal
+  scrollback), OMP_NUM_THREADS ≤ 16 for CPU stages, GPU for all DFT,
+  no multi-hour full-CPU jobs without Victor's explicit go. The
+  `quarry-campaign` skill is the checklist.
+- **Worktree discipline**: one branch = one worktree = one PR; main
+  worktree is read-only reference.
+- **PR lifecycle**: open it, let cloud Hermes drive Sourcery/merge
+  (`pr-merge-gauntlet` skill); after merge, sync local main.
+- **Barriers cross the QM→KMC bridge, never pre-exponentiated rates**
+  (petra's truncated R vs CODATA — gotchas.md).
+- **DFT owns every number that enters the KMC**; xtb/MLIPs may only
+  screen and guess (SURVEY §5).
+- **A verified saddle is not necessarily the right saddle** — the gates
+  exist because we produced three chemically-wrong-but-mechanically-
+  valid saddles in one evening. Trust the gates; when one aborts, read
+  the geometry before touching the code.
+- Big outputs stay out of git (`runs/` is gitignored); derived numbers +
+  provenance go in the store and the ledger.
+
+## 5. Open questions a session may hit (decide, log, proceed)
+
+- Cluster termination chemistry at Al edges (OH vs H₂O vs OH₂⁺) sets the
+  cluster charge — follow the pKa table for the target pH regime and
+  record the choice per cell in results.json.
+- How many explicit waters at the reactive site: survey norm is 3–6 for
+  water-mediated steps; Phase 1 used 1. Start with 1 for ladder
+  *trends* (ΔΔEa by connectivity is more transferable than absolute
+  heights), flag absolute numbers as needing the A2 tier + explicit
+  microsolvation.
+- If a ladder cell's mechanism differs qualitatively across n (concerted
+  → stepwise), that's a finding, not a bug — record both and emit the
+  rate-limiting barrier.

--- a/qm/HANDOFF.md
+++ b/qm/HANDOFF.md
@@ -145,7 +145,7 @@ connectivity n, protonation state) cell of the ladder":
 
 ## 4. Hard rules (unchanged, learned the hard way)
 
-- **Compute etiquette**: everything tee'd to files (never trust terminal
+- **Compute etiquette**: everything teed to files (never trust terminal
   scrollback), OMP_NUM_THREADS ≤ 16 for CPU stages, GPU for all DFT,
   no multi-hour full-CPU jobs without Victor's explicit go. The
   `quarry-campaign` skill is the checklist.


### PR DESCRIPTION
## Summary
Rewrites `qm/HANDOFF.md` as the **Phase 2 edition** — a self-contained build plan for a fresh session to execute the connectivity × protonation barrier ladder (the CALC-002..005 payload):

- State of the world: Phase 0/1 done (si-neutral ΔG‡ = 113.05 kJ/mol vs X&L ~29 kcal/mol), al-neutral's sequential mechanism in flight (TASK-168/PR #29 — not to be duplicated), parallel cards A1b/A2 and how Phase 2 relates (runs at the validated def2-svp tier; A2 re-tiers later)
- The two new builds: a crystallographic cluster builder cut from `petra/examples/kaolinite.toml`'s machine-readable cell (terminated, peripherally-frozen, per site family and pKa-derived protonation state) and a per-ladder-cell campaign driver reusing the proven scan/NEB/Sella/gate machinery
- Emission plan: petra `by_count`/`when` tables with provenance, round-trip compiled, one PR per family, ledger rows updated in the same PR
- Hard rules and measured failure modes carried forward; open questions pre-decided where possible

Board bookkeeping rides along per PROTOCOL: new READY card `A3-barrier-ladder` (P1, workstation), PLAN.md row, STATUS.md line. The Phase 0/1 handoff remains in git history at the same path.

## Test plan
Docs-only: markdown renders, PLAN table row well-formed, card follows the house format, no code touched. (Referenced paths verified to exist: kaolinite.toml `[cell]`, CALCULATIONS.md rows, repo skills, learnings files.)

## Breaking changes
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Define and register the Phase 2 barrier-ladder work needed to turn crystallographic site models into provenance-backed Petra kinetics tables.

New Features:
- Add the A3 Phase 2 plan for computing connectivity- and protonation-resolved barriers across the five KMC site families and emitting provenance-backed Petra environment tables.
- Add the READY A3-barrier-ladder program card defining its objective, dependencies, context, and acceptance criteria.

Enhancements:
- Replace the previous QM handoff with an operational Phase 2 guide covering crystallographic cluster construction, ladder campaigns, emission, execution order, and learned safeguards.

Documentation:
- Document the Phase 0/1 state, validated reference results, campaign constraints, failure modes, and Phase 2 execution decisions.

Tests:
- Define CPU-only cluster-builder gates and Petra compilation round-trip requirements for completed barrier families.

Chores:
- Register A3-barrier-ladder as a P1 workstation-ready item in the program plan and record the Phase 2 handoff in status tracking.