### PR TITLE
docs: board refresh + incremental-bookkeeping protocol amendment

### DIFF
--- a/docs/program/PLAN.md
+++ b/docs/program/PLAN.md
@@ -10,7 +10,7 @@ updated through the same PRs that do the work.*
 |---|---|---|
 | M0 — scoping + in-flight landed | ✅ done 2026-08-18 | Omnibus + 3 scoping docs merged; Phase-1 si-neutral barrier landed (ΔG‡ 27.0 kcal/mol vs X&L ~29) |
 | M1 — B1 schema RFC reviewed | ready | RFC-001 written (B1 done); awaiting Victor's review ack |
-| M2 — B2 refactor, parity green | blocked (B1) | |
+| M2 — B2 refactor, parity green | in progress | B2 READY as of B1 merge |
 | M3 — B3 conformance decks green | blocked (B2) | Conway / Ising / SIR with analytic gates |
 | M4 — B4 ensembles + observables | blocked (B2) | design against A5-Phase-0 needs |
 | M5 — first science on new platform | blocked (M3/M4) | A5 aging study ∥ C2 corrosion deck ∥ D2 rates campaign |
@@ -26,7 +26,7 @@ on main). Priority P0 > P1 > P2 within READY.
 | Card | Track | Priority | Machine | Status | Depends on |
 |---|---|---|---|---|---|
 | [B1-schema-rfc](cards/B1-schema-rfc.md) | B | P0 | any | done | — |
-| [D2a-astro-rate-reproduction](cards/D2a-astro-rate-reproduction.md) | D | P1 | workstation | ready | — |
+| [B2-engine-refactor](cards/B2-engine-refactor.md) | B | P0 | any | ready | B1 ✅ |
 | [A1b-acid-mechanisms](cards/A1b-acid-mechanisms.md) | A | P1 | workstation | ready | — |
 | [A3-barrier-ladder](cards/A3-barrier-ladder.md) | A | P1 | workstation | ready | — |
 | [A7-kinetics-database](cards/A7-kinetics-database.md) | A | P2 | any | done | — |
@@ -37,6 +37,12 @@ on main). Priority P0 > P1 > P2 within READY.
 | [C2-corrosion-deck](cards/C2-corrosion-deck.md) | C | P2 | any | blocked: B3 | B3 |
 | [D3-ice-mantle-deck](cards/D3-ice-mantle-deck.md) | D | P2 | any | blocked: B3 + D2a | B3, D2a |
 | [A5p0-aging-observables](cards/A5p0-aging-observables.md) | A | P1 | any | blocked: B4 | B4 |
+
+**Done** (acceptance verified on main): B1-schema-rfc (PR #25),
+D2a-astro-rate-reproduction (PR #31 — verdict: GO gas-phase /
+NO-GO surface-LH), A7-kinetics-database (PR #27 — 36 minerals, 74
+mechanisms, validator green). **Active**: A3-barrier-ladder
+(claim branch live).
 
 **Tracked elsewhere**: TASK-164 (scan-smoothness repair + al-neutral
 barrier) predates this board and lives in the mission-control queue —

--- a/docs/program/PLAN.md
+++ b/docs/program/PLAN.md
@@ -9,7 +9,7 @@ updated through the same PRs that do the work.*
 | Milestone | State | Notes |
 |---|---|---|
 | M0 — scoping + in-flight landed | ✅ done 2026-08-18 | Omnibus + 3 scoping docs merged; Phase-1 si-neutral barrier landed (ΔG‡ 27.0 kcal/mol vs X&L ~29) |
-| M1 — B1 schema RFC reviewed | ready | RFC-001 written (B1 done); awaiting Victor's review ack |
+| M1 — B1 schema RFC reviewed | ✅ done 2026-08-19 | RFC-001 merged (PR #25); B2 unblocked |
 | M2 — B2 refactor, parity green | in progress | B2 READY as of B1 merge |
 | M3 — B3 conformance decks green | blocked (B2) | Conway / Ising / SIR with analytic gates |
 | M4 — B4 ensembles + observables | blocked (B2) | design against A5-Phase-0 needs |
@@ -31,7 +31,6 @@ on main). Priority P0 > P1 > P2 within READY.
 | [A3-barrier-ladder](cards/A3-barrier-ladder.md) | A | P1 | workstation | ready | — |
 | [A7-kinetics-database](cards/A7-kinetics-database.md) | A | P2 | any | done | — |
 | [A2-production-energetics](cards/A2-production-energetics.md) | A | P1 | workstation | blocked: ORCA install (Victor) + A1b | A1b |
-| [B2-engine-refactor](cards/B2-engine-refactor.md) | B | P0 | any | blocked: Victor review ack of RFC-001 | B1 |
 | [B3-conformance-decks](cards/B3-conformance-decks.md) | B | P1 | any | blocked: B2 | B2 |
 | [B4-ensembles-observables](cards/B4-ensembles-observables.md) | B | P1 | any | blocked: B2 | B2 |
 | [C2-corrosion-deck](cards/C2-corrosion-deck.md) | C | P2 | any | blocked: B3 | B3 |

--- a/docs/program/PROTOCOL.md
+++ b/docs/program/PROTOCOL.md
@@ -59,6 +59,23 @@ normally.
 - Non-obvious discoveries go to `.claude/learnings/` (existing
   convention: topic files + INDEX.md one-liner).
 
+## Bookkeeping is incremental, not terminal (amendment, 2026-08-20)
+
+Learned from D2a: the worker did excellent science, then hit its
+tool-iteration ceiling during the closeout — summary, card update, and
+PR all unwritten (supervision finished them from artifacts). Rules:
+
+- **Push durable state as you go.** Implementation commits go up when
+  green, not at the end. Campaign artifacts checkpoint continuously.
+- **Update the card's Progress log at each stage boundary** (committed
+  and pushed), so a dead or capped worker leaves a legible trail.
+- **Budget the closeout.** When ~15% of your iteration budget remains,
+  STOP new work and execute the closeout (summary → card → STATUS →
+  PR). An incomplete card with finished bookkeeping beats a finished
+  card with no bookkeeping.
+- Exit reports matter: state precisely what is and is not done —
+  D2a's honest exit made supervision closeout a 15-minute job.
+
 ## Finishing a card — the single PR
 
 Your PR contains, atomically:

--- a/docs/program/PROTOCOL.md
+++ b/docs/program/PROTOCOL.md
@@ -69,10 +69,13 @@ PR all unwritten (supervision finished them from artifacts). Rules:
   green, not at the end. Campaign artifacts checkpoint continuously.
 - **Update the card's Progress log at each stage boundary** (committed
   and pushed), so a dead or capped worker leaves a legible trail.
-- **Budget the closeout.** When ~15% of your iteration budget remains,
-  STOP new work and execute the closeout (summary → card → STATUS →
-  PR). An incomplete card with finished bookkeeping beats a finished
-  card with no bookkeeping.
+- **Budget the closeout.** Your *iteration budget* is the worker's
+  tool-iteration ceiling (Hermes worker-profile `max_turns`); every
+  tool call — model turn, file read/write, shell command — spends one
+  iteration. Track turns used against the ceiling and, when ~15% of
+  the budget remains, STOP new work and execute the closeout (summary
+  → card → STATUS → PR). An incomplete card with finished bookkeeping
+  beats a finished card with no bookkeeping.
 - Exit reports matter: state precisely what is and is not done —
   D2a's honest exit made supervision closeout a 15-minute job.
 

--- a/docs/program/STATUS.md
+++ b/docs/program/STATUS.md
@@ -4,6 +4,10 @@
 appended by the PR that did it: `date — actor — what + pointer`.
 Deviations get a `DEVIATION:` note; details live in the card.*
 
+- 2026-08-20 — fable — Board refresh: B1+D2a+A7 done, B2 READY (keystone
+  merged), A3 active. PROTOCOL amendment: incremental bookkeeping
+  (the D2a iteration-ceiling lesson). Hermes worker-profile max_turns
+  raised 90 -> 1000 fleet-side (infra, not repo).
 - 2026-08-20 — local-hermes + fable — D2a DONE: 6-reaction astro rate
   campaign on the 4090. Verdict: GO gas-phase / NO-GO surface-LH rates
   (4–5 orders low without explicit-surface treatment). First non-Claude

--- a/docs/program/STATUS.md
+++ b/docs/program/STATUS.md
@@ -7,7 +7,9 @@ Deviations get a `DEVIATION:` note; details live in the card.*
 - 2026-08-20 — fable — Board refresh: B1+D2a+A7 done, B2 READY (keystone
   merged), A3 active. PROTOCOL amendment: incremental bookkeeping
   (the D2a iteration-ceiling lesson). Hermes worker-profile max_turns
-  raised 90 -> 1000 fleet-side (infra, not repo).
+  raised 90 -> 1000 fleet-side (infra, not repo; the raise gives workers
+  more headroom, but the PROTOCOL closeout rule still applies — budget
+  the last ~15% of turns so a capped worker leaves legible state).
 - 2026-08-20 — local-hermes + fable — D2a DONE: 6-reaction astro rate
   campaign on the 4090. Verdict: GO gas-phase / NO-GO surface-LH rates
   (4–5 orders low without explicit-surface treatment). First non-Claude


### PR DESCRIPTION
## Summary
Board catch-up after a big 24 hours: B1 (RFC), D2a (astro verdict), and A7 (kinetics DB) all merged — PLAN milestone/card tables now reflect it; B2-engine-refactor promoted to READY (the keystone gate is open); A3 noted active. PROTOCOL gains the D2a lesson as a standing rule: bookkeeping is incremental, not terminal — push durable state as you go, update the card at stage boundaries, and reserve the last ~15% of iteration budget for closeout. STATUS line included. (Fleet-side, not in this repo: Hermes worker-profile max_turns raised 90→1000, which was the D2a ceiling's root cause.)

## Test plan
Docs only.

## Breaking changes
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Refresh program tracking and formalize incremental bookkeeping practices so work remains recoverable when workers reach iteration limits.

Enhancements:
- Amend the protocol to require incremental durable-state updates, stage-boundary progress logging, and an explicit closeout budget for capped workers.
- Refresh the program board to record completed B1, D2a, and A7 work, promote B2 to ready, and identify A3 as active.

Documentation:
- Document the D2a bookkeeping lesson and update program status with the latest milestone and card state.