### PR TITLE
docs: card QI1 — driver-enforced compute etiquette

### DIFF
--- a/docs/program/PLAN.md
+++ b/docs/program/PLAN.md
@@ -27,6 +27,7 @@ on main). Priority P0 > P1 > P2 within READY.
 |---|---|---|---|---|---|
 | [B1-schema-rfc](cards/B1-schema-rfc.md) | B | P0 | any | done | — |
 | [B2-engine-refactor](cards/B2-engine-refactor.md) | B | P0 | any | ready | B1 ✅ |
+| [QI1-driver-enforced-etiquette](cards/QI1-driver-enforced-etiquette.md) | A | P2 | any | ready | — |
 | [A1b-acid-mechanisms](cards/A1b-acid-mechanisms.md) | A | P1 | workstation | ready | — |
 | [A3-barrier-ladder](cards/A3-barrier-ladder.md) | A | P1 | workstation | ready | — |
 | [A7-kinetics-database](cards/A7-kinetics-database.md) | A | P2 | any | done | — |

--- a/docs/program/STATUS.md
+++ b/docs/program/STATUS.md
@@ -4,6 +4,9 @@
 appended by the PR that did it: `date — actor — what + pointer`.
 Deviations get a `DEVIATION:` note; details live in the card.*
 
+- 2026-08-20 — fable — Card QI1: campaign drivers must enforce their own
+  thread caps + niceness (a live worker probe ran 22 threads past the
+  prompt-level cap — prompts don't bind subprocesses).
 - 2026-08-20 — fable — Board refresh: B1+D2a+A7 done, B2 READY (keystone
   merged), A3 active. PROTOCOL amendment: incremental bookkeeping
   (the D2a iteration-ceiling lesson). Hermes worker-profile max_turns

--- a/docs/program/cards/QI1-driver-enforced-etiquette.md
+++ b/docs/program/cards/QI1-driver-enforced-etiquette.md
@@ -1,0 +1,38 @@
+# QI1-driver-enforced-etiquette — campaign drivers enforce their own compute caps
+
+- status: ready
+- track: A (quarry infrastructure)
+- priority: P2
+- machine: any (code + tests; no campaigns needed)
+- depends: —
+- claimed-by: (see agents/QI1-driver-enforced-etiquette branch)
+
+## Objective
+
+Compute etiquette (OMP_NUM_THREADS ≤ 16, background niceness, teed
+logs) currently lives in prompts, skills, and docs — and 2026-08-20
+proved prompts don't bind subprocesses: a fleet worker's CPU probe ran
+~22 threads at nice 0 on the shared workstation (harmless, but only
+because the box was lightly loaded). Move enforcement into the code:
+
+1. A `quarry.etiquette` module: `enforce(threads=16, niceness=10)` that
+   hard-sets OMP/MKL/OPENBLAS thread env vars BEFORE numpy/pyscf import
+   and applies os.nice() — called at the top of every campaign
+   entry-point (phase1_xiao_lasaga.py, phase2_ladder.py, phase0_smoke,
+   and any future scripts/), overridable only by explicit CLI flag
+   (--threads, --nice), never by environment inheritance.
+2. Logging: entry-points refuse to run without a --log/tee path OR
+   self-tee to a timestamped file under runs/ and print the path first.
+3. Tests: enforce() sets the env vars when unset and clamps when set
+   higher; entry-points call it before heavy imports (import-order
+   test); CLI overrides work.
+
+## Acceptance
+
+- All qm/scripts entry-points call enforce() before heavy imports;
+  tests green; ruff clean; a deliberately-unset environment run shows
+  ≤16 threads (document the check in the PR).
+
+## Progress
+
+- 2026-08-20 — card created (fable) after the live 22-thread probe.

--- a/docs/program/cards/QI1-driver-enforced-etiquette.md
+++ b/docs/program/cards/QI1-driver-enforced-etiquette.md
@@ -16,16 +16,41 @@ proved prompts don't bind subprocesses: a fleet worker's CPU probe ran
 because the box was lightly loaded). Move enforcement into the code:
 
 1. A `quarry.etiquette` module: `enforce(threads=16, niceness=10)` that
-   hard-sets OMP/MKL/OPENBLAS thread env vars BEFORE numpy/pyscf import
-   and applies os.nice() — called at the top of every campaign
-   entry-point (phase1_xiao_lasaga.py, phase2_ladder.py, phase0_smoke,
-   and any future scripts/), overridable only by explicit CLI flag
-   (--threads, --nice), never by environment inheritance.
+   hard-sets thread env vars BEFORE numpy/pyscf import and applies
+   os.nice() — called at the top of every campaign entry-point
+   (phase1_xiao_lasaga.py, phase2_ladder.py, phase0_smoke, and any
+   future scripts/), overridable only by explicit CLI flag (--threads,
+   --nice), never by environment inheritance.
 2. Logging: entry-points refuse to run without a --log/tee path OR
    self-tee to a timestamped file under runs/ and print the path first.
-3. Tests: enforce() sets the env vars when unset and clamps when set
-   higher; entry-points call it before heavy imports (import-order
-   test); CLI overrides work.
+3. Tests: enforce() sets the env vars when unset, clamps when set
+   higher, and leaves them untouched when at/below the cap; entry-points
+   call it before heavy imports (import-order test); CLI overrides work
+   (including `--threads` raising the cap and negative `--nice` being
+   rejected for non-root); `os.nice()` failure warns and continues.
+
+## Spec clarifications
+
+- **Thread env vars managed** — `enforce()` sets exactly
+  `OMP_NUM_THREADS`, `MKL_NUM_THREADS`, and `OPENBLAS_NUM_THREADS`.
+  Clamping is one-directional: if a var is unset it is set to `threads`;
+  if already set **above** the cap it is clamped down to `threads`; if
+  already set **at or below** the cap it is left untouched (never
+  raised). This makes the "≤ cap, never inflate" contract unambiguous.
+- **`os.nice()` failure** — on platforms where `os.nice()` is unavailable
+  (non-POSIX) or raising niceness fails (e.g. containerized without
+  CAP_SYS_NICE), `enforce()` must **warn and continue** (log a
+  one-line warning to stderr), not fail hard. Thread caps still apply;
+  only the niceness best-effort degrades.
+- **CLI override semantics** — `--threads` may **raise** the cap above 16
+  (explicit operator intent wins over the default), but may not lower it
+  below 1. `--nice` accepts any value `os.nice()` will accept; negative
+  (higher-priority) values are **rejected** unless the process is
+  running as root, and root-only values are otherwise refused with a
+  clear error. When multiple sources conflict (CLI flag vs. env var vs.
+  default), precedence is: explicit CLI flag > default; environment
+  inheritance is **never** a source (env vars are overwritten, not
+  read).
 
 ## Acceptance
 


### PR DESCRIPTION
## Summary
New READY card: move compute etiquette (thread caps, niceness, mandatory teed logs) from prompts/skills into the campaign drivers themselves — tonight a fleet worker's CPU probe ran ~22 threads past the prompt-level 16-thread cap, demonstrating that prompt discipline doesn't bind subprocesses. `quarry.etiquette.enforce()` called before heavy imports in every entry-point, override only by explicit CLI flag. machine:any, laptop-friendly.

## Test plan
Docs only; the card's acceptance carries the tests.

## Breaking changes
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Define the QI1 work needed to move compute etiquette enforcement from prompts and documentation into campaign drivers.

Enhancements:
- Add a READY infrastructure card defining driver-enforced compute limits, process niceness, and mandatory run logging for campaign entry points.
- Document explicit CLI override semantics, environment-independent enforcement, graceful niceness failures, and required test coverage.

Documentation:
- Record QI1 in the program status and plan and add its acceptance criteria and implementation specification.