### PR TITLE
feat(qm): A3 Phase-2 platform — crystallographic cluster builder + ladder campaign driver

### DIFF
--- a/.claude/learnings/INDEX.md
+++ b/.claude/learnings/INDEX.md
@@ -1,5 +1,5 @@
 # Learnings Index
 
 - [gotchas.md](gotchas.md) — Petra decks need `[simulation]` even for validation; pyscf thermo auto-applies rotational symmetry numbers (R·ln σ entropy trap); petra's truncated gas constant vs CODATA (send barriers over the bridge, never rates); legacy-crude kaolinite cell geometry is a frozen-shell systematic (freeze heavies only, never constructed H)
-- [performance.md](performance.md) — first 4090-vs-CPU DFT timings: small jobs favor CPU; GPU wins need density fitting + warmup + cuTENSOR + ~100 atoms
+- [performance.md](performance.md) — first 4090-vs-CPU DFT timings: small jobs favor CPU; GPU wins need density fitting + warmup + cuTENSOR + ~100 atoms; cutensor-cu12 wheel needs an explicit preload or cupy silently falls back to einsum and OOMs at ~60 atoms
 - [debugging.md](debugging.md) — trivial-saddle trap: verified ≠ right saddle; interior scan maximum required before Sella; CuPy pool fragmentation OOMs multi-hour GPU runs (trim at stage boundaries; pipefail with tee)

--- a/.claude/learnings/INDEX.md
+++ b/.claude/learnings/INDEX.md
@@ -1,5 +1,5 @@
 # Learnings Index
 
-- [gotchas.md](gotchas.md) — Petra decks need `[simulation]` even for validation; pyscf thermo auto-applies rotational symmetry numbers (R·ln σ entropy trap); petra's truncated gas constant vs CODATA (send barriers over the bridge, never rates)
+- [gotchas.md](gotchas.md) — Petra decks need `[simulation]` even for validation; pyscf thermo auto-applies rotational symmetry numbers (R·ln σ entropy trap); petra's truncated gas constant vs CODATA (send barriers over the bridge, never rates); legacy-crude kaolinite cell geometry is a frozen-shell systematic (freeze heavies only, never constructed H)
 - [performance.md](performance.md) — first 4090-vs-CPU DFT timings: small jobs favor CPU; GPU wins need density fitting + warmup + cuTENSOR + ~100 atoms
 - [debugging.md](debugging.md) — trivial-saddle trap: verified ≠ right saddle; interior scan maximum required before Sella

--- a/.claude/learnings/INDEX.md
+++ b/.claude/learnings/INDEX.md
@@ -2,4 +2,4 @@
 
 - [gotchas.md](gotchas.md) — Petra decks need `[simulation]` even for validation; pyscf thermo auto-applies rotational symmetry numbers (R·ln σ entropy trap); petra's truncated gas constant vs CODATA (send barriers over the bridge, never rates); legacy-crude kaolinite cell geometry is a frozen-shell systematic (freeze heavies only, never constructed H)
 - [performance.md](performance.md) — first 4090-vs-CPU DFT timings: small jobs favor CPU; GPU wins need density fitting + warmup + cuTENSOR + ~100 atoms
-- [debugging.md](debugging.md) — trivial-saddle trap: verified ≠ right saddle; interior scan maximum required before Sella
+- [debugging.md](debugging.md) — trivial-saddle trap: verified ≠ right saddle; interior scan maximum required before Sella; CuPy pool fragmentation OOMs multi-hour GPU runs (trim at stage boundaries; pipefail with tee)

--- a/.claude/learnings/debugging.md
+++ b/.claude/learnings/debugging.md
@@ -9,3 +9,12 @@ Diagnosis signature: the saddle's driven coordinate far past the guess and
 both quick-IRC ends identical to the reactant complex. Fixes in quarry:
 scan_to_maximum (extend until interior max) + escaped-channel guard in
 the phase-1 driver. A verified saddle is not necessarily the right saddle.
+
+### CuPy pool fragmentation OOMs multi-hour GPU campaigns (2026-08-19)
+First Phase-2 pilot: stage 1 (2 h of geomeTRIC steps on a 66-atom cluster)
+ran fine at ~7 GB, then the first stage-2 DF-K gradient died with
+cudaErrorMemoryAllocation on the 24 GB card — the CuPy memory pool had
+fragmented across thousands of allocations. Fix: free_all_blocks() on the
+default + pinned pools at every stage boundary and scan point
+(phase2_ladder.trim_gpu_pool). Also: `cmd | tee log` reports tee's exit
+code — a crashed driver looks like exit 0 unless `set -o pipefail`.

--- a/.claude/learnings/gotchas.md
+++ b/.claude/learnings/gotchas.md
@@ -20,3 +20,14 @@ rate differs by ~0.17%. Negligible against DFT barrier error, but it means
 the QM→KMC bridge should always transmit barriers/ΔH‡/ΔS‡ and let the
 engine exponentiate — never pre-computed rate constants
 (documented in qm/tests/test_rates.py::test_petra_gate_value).
+
+### The kaolinite cell crystallography is legacy-crude (2026-08-19)
+The deck cell (petra/examples/kaolinite.toml [cell]) faithfully imports the
+dissertation-era data.cell, whose bond lengths run 1.38-2.88 A (real
+kaolinite: Si-O ~1.6, Al-O ~1.9). Fine for lattice KMC (topology only), but
+QM clusters cut from it start strained and the *frozen shell keeps those
+positions forever* — a systematic in every lattice-resistance number until
+someone re-derives the cell from a modern refinement (Bish 1993). The free
+region re-optimizes, so trends (ΔΔEa by connectivity) are safer than
+absolute barriers. Never freeze constructed protons: H positions are
+guesses, not crystallography (quarry/crystal.py freezes heavy atoms only).

--- a/.claude/learnings/performance.md
+++ b/.claude/learnings/performance.md
@@ -10,3 +10,14 @@ gpu4pyscf warned and fell back to CuPy contractions. smoke v2 fixes all
 three (warmup pass, DF default, cutensor-cu12 in the [gpu] extra) and adds
 --waters up to 24 to probe the 100+-atom regime; expect the survey's 2–5×
 (SCF/grad) and 5–10× (Hessian) only there. Small jobs should just run CPU.
+
+### cutensor-cu12 wheel is invisible to cupy without a preload (2026-08-19)
+The `cutensor-cu12` wheel installs its .so files to
+site-packages/cutensor/lib, which is NOT on the dynamic loader path, so
+cupy silently falls back to its einsum contraction engine (gpu4pyscf
+warns once: "using cupy as the tensor contraction engine"). At ~60
+atoms/def2-svp the fallback's temporaries OOM a 24 GB 4090 in the DF-K
+gradient — cuTENSOR isn't just speed, it's feasibility. Fix: ctypes-CDLL
+the libs with RTLD_GLOBAL before first cupy contraction
+(phase2_ladder.preload_cutensor) or export
+LD_LIBRARY_PATH=$VENV/lib/python3.13/site-packages/cutensor/lib.

--- a/docs/program/STATUS.md
+++ b/docs/program/STATUS.md
@@ -4,6 +4,13 @@
 appended by the PR that did it: `date — actor — what + pointer`.
 Deviations get a `DEVIATION:` note; details live in the card.*
 
+- 2026-08-19 — fable — A3-barrier-ladder claimed + platform half landed:
+  crystallographic cluster builder (`qm/quarry/crystal.py`, deck-cell
+  parser + bond-valence termination/charge + n_intact pruning + frozen
+  shell), PHVA frequencies for frozen clusters, and the per-cell campaign
+  driver (`qm/scripts/phase2_ladder.py`). Pilot cell oss-neutral running
+  on the GPU; barriers land in follow-up per-family PRs.
+
 - 2026-08-18 — hermes-workstation — A7-kinetics-database done: schema v0,
   36 P&K silicate records / 74 mechanisms, stdlib validator, and a
   49-source 2004–present expansion inventory under `kinetics-db/`.

--- a/docs/program/cards/A3-barrier-ladder.md
+++ b/docs/program/cards/A3-barrier-ladder.md
@@ -1,13 +1,13 @@
 # A3-barrier-ladder — connectivity × protonation barrier ladder (Phase 2)
 
-- status: ready
+- status: in-progress
 - track: A (geochemistry)
 - priority: P1
 - machine: workstation (GPU campaigns; cluster-builder code is machine-any)
 - depends: — (runs at the validated b3lyp/def2-svp/df tier; A2 re-tiers
   the finished ladder later; acid-state variants may reuse A1b's
   protonated-bridge machinery when it lands but are not blocked by it)
-- claimed-by:
+- claimed-by: fable (agents/A3-barrier-ladder, 2026-08-19)
 
 ## Objective
 Execute qm/HANDOFF.md (Phase 2 edition — the full build plan lives
@@ -42,3 +42,17 @@ with provenance. Closes CALCULATIONS.md rows CALC-002..005 from
 
 ## Progress
 - 2026-08-19 — card created with the Phase-2 handoff rewrite (fable).
+- 2026-08-19 — claimed; cluster builder (`qm/quarry/crystal.py`) +
+  campaign driver (`qm/scripts/phase2_ladder.py`) built and gated
+  (27 new CPU-only tests, full fast suite 117 green, ruff clean).
+  DEVIATION: builder lives in a new module `quarry/crystal.py`, not as
+  a clusters.py extension (clusters.py stays the hand-built benchmark
+  set; the Cluster contract is shared). Pilot cell oss-neutral-n4-s2
+  (Al3H25O29Si6, 63 atoms, 29 frozen heavies) launched on the GPU.
+  Findings so far: (1) the deck cell faithfully imports the legacy
+  data.cell crystallography, which is crude (bonds 1.38–2.88 A) — a
+  logged systematic in every frozen-shell number (learnings/gotchas);
+  (2) constructed protons are never frozen — only crystallographic
+  heavy atoms; (3) frequencies() now does partial-Hessian analysis on
+  frozen clusters (no trans/rot projection), so verify/IRC/thermo flow
+  through the existing machinery unchanged.

--- a/qm/quarry/crystal.py
+++ b/qm/quarry/crystal.py
@@ -1,0 +1,588 @@
+"""Crystallographic cluster builder — Phase 2 (HANDOFF.md §2a).
+
+Cuts terminated, peripherally-frozen clusters from the mineral unit cell
+carried by a petra deck. The deck's ``[cell]`` section is the single
+source of crystallographic truth: fractional sites, the frac→Cartesian
+matrix (lattice vectors as *columns*, petra-core crystal.rs convention),
+and the KMC bond graph with periodic ``dcell`` image offsets. The graph
+carries full coordination (kaolinite: Si degree 4, Al degree 6, Osa is
+the real 3-coordinate apical oxygen, Oaa the structural hydroxyl), so
+termination and charge bookkeeping follow from Pauling bond valence
+alone — no chemistry tables beyond Si–O = 1.0, Al–O = 0.5, O wants 2.
+
+Termination rules (SURVEY.md §6.2, Pelmenschikov lattice resistance):
+every bridge oxygen adjacent to an included metal is kept at its
+crystallographic position; oxygens missing metal partners are capped
+with H per bond-valence deficit, then protons are added/removed at the
+most under/over-saturated peripheral oxygens until the target charge is
+met. The outermost metal shell (and everything exclusively attached to
+it) is frozen — lattice resistance is physics, not a detail.
+"""
+
+from __future__ import annotations
+
+import math
+import tomllib
+from collections import deque
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import numpy as np
+
+from quarry.clusters import R_O_H, Cluster, SiteFamily, _unit, merge
+
+KIND_TO_FAMILY = {
+    "Al": SiteFamily.AL,
+    "Si": SiteFamily.SI,
+    "Oss": SiteFamily.SI_O_SI,
+    "Osa": SiteFamily.SI_O_AL2,
+    "Oaa": SiteFamily.AL_OH_AL,
+}
+KIND_ELEMENT = {"Al": "Al", "Si": "Si", "Oss": "O", "Osa": "O", "Oaa": "O"}
+METAL_KINDS = frozenset({"Al", "Si"})
+# Pauling bond strength per M-O bond: cation valence / coordination.
+PAULING_STRENGTH = {"Si": 1.0, "Al": 0.5}
+FORMAL_CHARGE = {"Si": 4, "Al": 3}
+# Structural protons the mineral itself carries (Al-OH-Al is a hydroxyl).
+STRUCTURAL_H = {"Oaa": 1}
+O_VALENCE = 2.0
+MIN_INTERATOMIC_A = 0.75
+
+# A node is one site in one periodic image.
+Node = tuple[int, tuple[int, int, int]]
+
+
+@dataclass(frozen=True)
+class CellSite:
+    kind: str
+    frac: tuple[float, float, float]
+
+
+@dataclass(frozen=True)
+class CellBond:
+    i: int
+    j: int
+    dcell: tuple[int, int, int]
+
+
+@dataclass
+class DeckCell:
+    """The ``[cell]`` section of a petra deck, with a lazy periodic graph."""
+
+    matrix: np.ndarray  # 3x3, columns are the lattice vectors
+    sites: list[CellSite]
+    bonds: list[CellBond]
+    _adjacency: dict[int, list[tuple[int, tuple[int, int, int]]]] = field(
+        default_factory=dict, repr=False
+    )
+
+    def __post_init__(self) -> None:
+        unknown = {s.kind for s in self.sites} - set(KIND_TO_FAMILY)
+        if unknown:
+            raise ValueError(f"unknown site kinds in deck cell: {sorted(unknown)}")
+        adj: dict[int, list[tuple[int, tuple[int, int, int]]]] = {
+            i: [] for i in range(len(self.sites))
+        }
+        for b in self.bonds:
+            adj[b.i].append((b.j, b.dcell))
+            adj[b.j].append((b.i, tuple(-d for d in b.dcell)))
+        self._adjacency = adj
+
+    @classmethod
+    def from_deck(cls, path: str | Path) -> DeckCell:
+        with open(path, "rb") as fh:
+            deck = tomllib.load(fh)
+        cell = deck.get("cell")
+        if cell is None:
+            raise ValueError(f"{path}: deck has no [cell] section")
+        sites = [
+            CellSite(kind=s["kind"], frac=tuple(float(x) for x in s["frac"]))
+            for s in cell["sites"]
+        ]
+        bonds = [
+            CellBond(
+                i=int(b["i"]),
+                j=int(b["j"]),
+                dcell=tuple(int(d) for d in b.get("dcell", [0, 0, 0])),
+            )
+            for b in cell.get("bonds", [])
+        ]
+        matrix = np.asarray(cell["matrix"], dtype=float)
+        return cls(matrix=matrix, sites=sites, bonds=bonds)
+
+    def kind(self, node: Node) -> str:
+        return self.sites[node[0]].kind
+
+    def cart(self, node: Node) -> np.ndarray:
+        site, image = node
+        frac = np.asarray(self.sites[site].frac) + np.asarray(image, dtype=float)
+        return self.matrix @ frac
+
+    def neighbors(self, node: Node) -> list[Node]:
+        site, image = node
+        out = []
+        for j, dcell in self._adjacency[site]:
+            out.append((j, tuple(a + d for a, d in zip(image, dcell, strict=True))))
+        return sorted(out)
+
+    def degree(self, site: int) -> int:
+        return len(self._adjacency[site])
+
+    def first_site_of_kind(self, kind: str) -> int:
+        for i, s in enumerate(self.sites):
+            if s.kind == kind:
+                return i
+        raise ValueError(f"deck cell has no site of kind '{kind}'")
+
+
+@dataclass
+class CrystalCluster:
+    """A built cluster plus the bookkeeping the campaign driver needs."""
+
+    cluster: Cluster
+    site_kind: str
+    center_site: int
+    metal_shells: int
+    # Atom index of the center bridge oxygen (None for metal-family centers).
+    bridge_index: int | None
+    # Atom index of the metal the attacker approaches.
+    attacked_index: int
+    n_intact_requested: int | None
+    n_intact: int
+    # Per-atom metal-shell provenance (H atoms inherit their oxygen's shell).
+    atom_shell: list[int]
+    termination_log: list[str] = field(default_factory=list)
+
+    def metadata(self) -> dict:
+        c = self.cluster
+        return {
+            "name": c.name,
+            "site_kind": self.site_kind,
+            "site_family": c.site_family.name if c.site_family else None,
+            "center_site": self.center_site,
+            "metal_shells": self.metal_shells,
+            "bridge_index": self.bridge_index,
+            "attacked_index": self.attacked_index,
+            "n_intact_requested": self.n_intact_requested,
+            "n_intact": self.n_intact,
+            "n_atoms": len(c.symbols),
+            "formula": c.formula,
+            "charge": c.charge,
+            "n_frozen": len(c.frozen_indices),
+            "termination_log": self.termination_log,
+        }
+
+
+def _formal_charge(symbols: list[str], n_h: int) -> int:
+    q = n_h  # each proton is +1 against the O2- lattice
+    for s in symbols:
+        if s in FORMAL_CHARGE:
+            q += FORMAL_CHARGE[s]
+        elif s == "O":
+            q -= 2
+        elif s != "H":
+            raise ValueError(f"unexpected element '{s}' in formal-charge bookkeeping")
+    return q
+
+
+def _h_directions(away: np.ndarray, n_h: int) -> list[np.ndarray]:
+    """Unit vectors for ``n_h`` protons on an O whose open side is ``away``.
+
+    Tilted off the away-axis (25 deg for OH, 52.25 deg each for OH2 so the
+    H-O-H angle lands near 104.5 deg). Only topology matters — the
+    pipeline optimizes every guess.
+    """
+    if not 1 <= n_h <= 2:
+        raise ValueError("an oxygen carries at most two protons")
+    base = _unit(away)
+    ref = np.array([1.0, 0.0, 0.0])
+    if abs(float(np.dot(ref, base))) > 0.9:
+        ref = np.array([0.0, 1.0, 0.0])
+    e1 = _unit(np.cross(base, ref))
+    e2 = np.cross(base, e1)
+    theta = math.radians(25.0 if n_h == 1 else 52.25)
+    phis = [0.0] if n_h == 1 else [0.0, math.pi]
+    return [
+        math.cos(theta) * base + math.sin(theta) * (math.cos(p) * e1 + math.sin(p) * e2)
+        for p in phis
+    ]
+
+
+def min_interatomic_distance(coords: np.ndarray) -> float:
+    d = np.linalg.norm(coords[:, None, :] - coords[None, :, :], axis=-1)
+    iu = np.triu_indices(len(coords), k=1)
+    return float(d[iu].min()) if iu[0].size else math.inf
+
+
+def from_deck_cell(
+    deck_path: str | Path,
+    site_kind: str,
+    *,
+    center_index: int | None = None,
+    metal_shells: int = 2,
+    n_intact: int | None = None,
+    target_charge: int = 0,
+    name: str | None = None,
+) -> CrystalCluster:
+    """Cut a terminated, peripherally-frozen cluster around one site.
+
+    ``site_kind`` picks the KMC family (Al/Si/Oss/Osa/Oaa);
+    ``center_index`` a specific cell site (default: first of that kind).
+    ``metal_shells`` is the cutoff in metal shells from the center;
+    the outermost shell is frozen (none frozen when ``metal_shells < 2``).
+    ``n_intact`` is the number of intact bridges on the attacked metal,
+    center bridge included — the connectivity rung of the ladder. Pruned
+    bridges have their partner metals removed ("dissolved") and become
+    terminal oxygens; bridges shared with a center-bridge partner
+    (edge-sharing octahedra) are unprunable and stay intact.
+    """
+    cell = DeckCell.from_deck(deck_path)
+    if site_kind not in KIND_TO_FAMILY:
+        raise ValueError(f"unknown site kind '{site_kind}'")
+    center_site = (
+        cell.first_site_of_kind(site_kind) if center_index is None else center_index
+    )
+    if cell.kind((center_site, (0, 0, 0))) != site_kind:
+        raise ValueError(
+            f"center site {center_site} is kind "
+            f"'{cell.sites[center_site].kind}', not '{site_kind}'"
+        )
+    center: Node = (center_site, (0, 0, 0))
+    is_bridge_center = site_kind not in METAL_KINDS
+    log: list[str] = []
+
+    # --- pick the attacked metal and the sacrosanct center partners ----
+    if is_bridge_center:
+        center_partners = cell.neighbors(center)
+        si_partners = [m for m in center_partners if cell.kind(m) == "Si"]
+        attacked_node = si_partners[0] if si_partners else center_partners[0]
+    else:
+        center_partners = []
+        attacked_node = center
+
+    # --- connectivity pruning on the attacked metal ---------------------
+    attacked_bridges = cell.neighbors(attacked_node)
+    max_n = len(attacked_bridges)
+    if n_intact is not None and not 1 <= n_intact <= max_n:
+        raise ValueError(
+            f"n_intact must be in 1..{max_n} for a "
+            f"{cell.kind(attacked_node)} center (got {n_intact})"
+        )
+    # A pruned bridge's partner metals are "dissolved" (excluded from the
+    # cluster); the bridge oxygen itself survives as a terminal OH on the
+    # attacked metal — that is Q-notation chemistry. Bridges touching a
+    # center-bridge partner are unprunable, and dissolving a partner
+    # cascades to every bridge that shares it (edge-sharing octahedra).
+    partners_of = {
+        b: frozenset(
+            m
+            for m in cell.neighbors(b)
+            if m != attacked_node and cell.kind(m) in METAL_KINDS
+        )
+        for b in attacked_bridges
+    }
+    unprunable = {
+        b
+        for b in attacked_bridges
+        if b == center or partners_of[b] & set(center_partners)
+    }
+    excluded_metals: set[Node] = set()
+    if n_intact is None:
+        kept = list(attacked_bridges)
+    else:
+        kept = sorted(unprunable)
+        for b in sorted(b for b in attacked_bridges if b not in unprunable):
+            if len(kept) < n_intact and not partners_of[b] & excluded_metals:
+                kept.append(b)
+            else:
+                excluded_metals |= partners_of[b]
+                log.append(f"pruned bridge {b}: partner metals dissolved")
+        # Cascade: a kept bridge whose partner dissolved is pruned too.
+        changed = True
+        while changed:
+            changed = False
+            for b in list(kept):
+                if b != center and partners_of[b] & excluded_metals:
+                    kept.remove(b)
+                    excluded_metals |= partners_of[b]
+                    log.append(f"pruned bridge {b}: cascade (shared partner)")
+                    changed = True
+        if len(kept) != n_intact:
+            log.append(
+                f"DEVIATION: requested n_intact={n_intact}, delivered "
+                f"{len(kept)} (unprunable/edge-sharing constraints)"
+            )
+    resolved_n_intact = len(kept)
+
+    # --- metal BFS to the shell cutoff ----------------------------------
+    metal_shell: dict[Node, int] = {}
+    queue: deque[Node] = deque()
+    if is_bridge_center:
+        for m in center_partners:
+            metal_shell[m] = 1
+            queue.append(m)
+    else:
+        metal_shell[attacked_node] = 0
+        queue.append(attacked_node)
+    while queue:
+        m = queue.popleft()
+        if metal_shell[m] >= metal_shells:
+            continue
+        for b in sorted(cell.neighbors(m)):
+            for m2 in cell.neighbors(b):
+                if (
+                    m2 != m
+                    and cell.kind(m2) in METAL_KINDS
+                    and m2 not in excluded_metals
+                    and m2 not in metal_shell
+                ):
+                    metal_shell[m2] = metal_shell[m] + 1
+                    queue.append(m2)
+
+    # --- collect bridge oxygens adjacent to included metals -------------
+    # (a pruned bridge re-enters here as a terminal oxygen: its partner
+    # metals are excluded, so only the attacked metal claims it)
+    bridge_metals: dict[Node, list[Node]] = {}
+    for m in metal_shell:
+        for b in cell.neighbors(m):
+            bridge_metals.setdefault(b, []).append(m)
+    if is_bridge_center and center not in bridge_metals:
+        raise RuntimeError("center bridge lost during cluster construction")
+
+    def bridge_shell(b: Node) -> int:
+        if is_bridge_center and b == center:
+            return 0
+        return min(metal_shell[m] for m in bridge_metals[b])
+
+    # --- assemble heavy atoms (deterministic order) ---------------------
+    symbols: list[str] = []
+    coords: list[np.ndarray] = []
+    shells: list[int] = []
+    atom_of: dict[Node, int] = {}
+
+    def add(node: Node, shell: int) -> int:
+        atom_of[node] = len(symbols)
+        symbols.append(KIND_ELEMENT[cell.kind(node)])
+        coords.append(cell.cart(node))
+        shells.append(shell)
+        return atom_of[node]
+
+    bridge_index: int | None = None
+    if is_bridge_center:
+        bridge_index = add(center, 0)
+    for m in sorted(metal_shell, key=lambda n: (metal_shell[n], n)):
+        add(m, metal_shell[m])
+    for b in sorted(bridge_metals, key=lambda n: (bridge_shell(n), n)):
+        if b not in atom_of:
+            add(b, bridge_shell(b))
+    attacked_index = atom_of[attacked_node]
+
+    # --- proton bookkeeping by bond valence ------------------------------
+    # deficit = 2 - sum(strengths of included metals) - structural H.
+    o_records = []  # (atom_idx, node, n_h, residual)
+    for b, metals in sorted(bridge_metals.items()):
+        strengths = sum(PAULING_STRENGTH[cell.kind(m)] for m in metals)
+        structural = STRUCTURAL_H.get(cell.kind(b), 0)
+        deficit = O_VALENCE - strengths - structural
+        n_base = max(0, math.floor(deficit + 1e-9))
+        n_h = structural + n_base
+        residual = deficit - n_base
+        if len(metals) < cell.degree(b[0]):
+            log.append(
+                f"terminal O {b}: {len(metals)}/{cell.degree(b[0])} metals, "
+                f"{n_h} H (residual {residual:+.1f})"
+            )
+        o_records.append([atom_of[b], b, n_h, residual])
+
+    n_h_total = sum(r[2] for r in o_records)
+    q0 = _formal_charge(symbols, n_h_total)
+    need = target_charge - q0
+    center_pos = cell.cart(center)
+
+    def far_first(rec):
+        return -float(np.linalg.norm(np.asarray(coords[rec[0]]) - center_pos))
+
+    reactive = {attacked_index, bridge_index}
+    if need > 0:
+        candidates = sorted(
+            (r for r in o_records if r[3] >= 0.5 - 1e-9 and r[2] < 2), key=far_first
+        )
+        candidates = [r for r in candidates if r[0] not in reactive]
+        if len(candidates) < need:
+            raise ValueError(
+                f"cannot reach charge {target_charge}: need {need} extra "
+                f"protons, only {len(candidates)} protonatable oxygens"
+            )
+        for r in candidates[:need]:
+            r[2] += 1
+            r[3] -= 1.0
+            log.append(f"protonated O {r[1]} for charge balance")
+    elif need < 0:
+        candidates = sorted(
+            (r for r in o_records if r[2] >= 1 and r[0] not in reactive),
+            key=lambda r: (r[3], far_first(r)),
+        )
+        if len(candidates) < -need:
+            raise ValueError(
+                f"cannot reach charge {target_charge}: need {-need} "
+                f"deprotonations, only {len(candidates)} candidates"
+            )
+        for r in candidates[: -need]:
+            r[2] -= 1
+            r[3] += 1.0
+            log.append(f"deprotonated O {r[1]} for charge balance")
+
+    # --- place protons ----------------------------------------------------
+    for o_idx, b, n_h, _residual in o_records:
+        if n_h == 0:
+            continue
+        o_pos = np.asarray(coords[o_idx])
+        metal_dirs = [
+            _unit(np.asarray(coords[atom_of[m]]) - o_pos) for m in bridge_metals[b]
+        ]
+        away = -np.sum(metal_dirs, axis=0)
+        if float(np.linalg.norm(away)) < 1e-3:
+            away = np.cross(metal_dirs[0], [1.0, 0.0, 0.0])
+            if float(np.linalg.norm(away)) < 1e-3:
+                away = np.cross(metal_dirs[0], [0.0, 1.0, 0.0])
+        for d in _h_directions(away, n_h):
+            symbols.append("H")
+            coords.append(o_pos + R_O_H * d)
+            shells.append(shells[o_idx])
+
+    # --- frozen shell -----------------------------------------------------
+    # Heavy atoms of the outermost metal shell freeze at crystallographic
+    # positions (lattice resistance); protons never freeze — their
+    # positions are constructed guesses, not crystallography.
+    frozen = (
+        [
+            i
+            for i, (s, sym) in enumerate(zip(shells, symbols, strict=True))
+            if s >= metal_shells and sym != "H"
+        ]
+        if metal_shells >= 2
+        else []
+    )
+    if not frozen:
+        log.append("no frozen shell (metal_shells < 2) — free-cluster model")
+
+    n_h_final = sum(1 for s in symbols if s == "H")
+    q_final = _formal_charge(symbols, n_h_final)
+    if q_final != target_charge:
+        raise RuntimeError(
+            f"charge bookkeeping failed: built {q_final}, target {target_charge}"
+        )
+
+    coords_arr = np.asarray(coords)
+    dmin = min_interatomic_distance(coords_arr)
+    if dmin < MIN_INTERATOMIC_A:
+        raise RuntimeError(
+            f"atom collision in built cluster: min distance {dmin:.2f} A"
+        )
+    reactive_frozen = attacked_index in frozen or (
+        bridge_index is not None and bridge_index in frozen
+    )
+    if reactive_frozen:
+        raise RuntimeError("reactive center landed in the frozen shell")
+
+    tag = f"{site_kind.lower()}-c{center_site}-s{metal_shells}-n{resolved_n_intact}"
+    cluster = Cluster(
+        name=name or f"crystal-{tag}",
+        symbols=symbols,
+        coords=coords_arr,
+        charge=target_charge,
+        frozen_indices=frozen,
+        site_family=KIND_TO_FAMILY[site_kind],
+        note=f"cut from {Path(deck_path).name} cell",
+    )
+    return CrystalCluster(
+        cluster=cluster,
+        site_kind=site_kind,
+        center_site=center_site,
+        metal_shells=metal_shells,
+        bridge_index=bridge_index,
+        attacked_index=attacked_index,
+        n_intact_requested=n_intact,
+        n_intact=resolved_n_intact,
+        atom_shell=shells,
+        termination_log=log,
+    )
+
+
+def attack_complex(
+    cc: CrystalCluster,
+    attacker: Cluster,
+    *,
+    approach_a: float = 3.2,
+    theta_deg: float = 80.0,
+    n_azimuths: int = 24,
+) -> tuple[Cluster, int]:
+    """Place the attacker for hydrolysis of the center bridge.
+
+    Flank geometry as in Phase 1 (attacker O ~80 deg off the M->Obr axis,
+    first O-H aimed at the bridging O), but the azimuth is searched for
+    maximum clearance from the rest of the cluster — a crystallographic
+    cluster is crowded where a hand-built dimer was not. Returns the
+    merged cluster and the attacker-oxygen atom index.
+    """
+    from quarry.clusters import _rotation_between
+
+    c = cc.cluster
+    m_pos = c.coords[cc.attacked_index]
+    if cc.bridge_index is not None:
+        axis = _unit(c.coords[cc.bridge_index] - m_pos)
+    else:
+        # Metal-family center: approach along the least-coordinated side.
+        o_dirs = [
+            _unit(c.coords[i] - m_pos)
+            for i, s in enumerate(c.symbols)
+            if s == "O" and np.linalg.norm(c.coords[i] - m_pos) < 2.3
+        ]
+        axis = -_unit(np.sum(o_dirs, axis=0))
+    ref = np.array([1.0, 0.0, 0.0])
+    if abs(float(np.dot(ref, axis))) > 0.9:
+        ref = np.array([0.0, 1.0, 0.0])
+    e1 = _unit(np.cross(axis, ref))
+    e2 = np.cross(axis, e1)
+
+    # Crystallographic clusters are crowded: search azimuth first at the
+    # requested polar angle, then widen the polar angle (nearest-to-
+    # requested first) until a clear approach exists. The proton stays
+    # deliverable to the bridge anywhere in this cone.
+    if cc.bridge_index is not None:
+        thetas = [theta_deg, 70.0, 90.0, 60.0, 100.0, 110.0]
+    else:
+        thetas = [0.0]
+    best_target, best_score = None, -math.inf
+    for th in thetas:
+        theta = math.radians(th)
+        for k in range(n_azimuths if theta > 0 else 1):
+            phi = 2.0 * math.pi * k / n_azimuths
+            direction = math.cos(theta) * axis + math.sin(theta) * (
+                math.cos(phi) * e1 + math.sin(phi) * e2
+            )
+            target = m_pos + approach_a * direction
+            score = float(np.min(np.linalg.norm(c.coords - target, axis=1)))
+            if score > best_score:
+                best_target, best_score = target, score
+        if best_score >= 2.0:
+            break
+    assert best_target is not None
+    if best_score < 1.6:
+        raise RuntimeError(
+            f"no attack direction with >=1.6 A clearance (best {best_score:.2f} A)"
+        )
+
+    shifted = attacker.coords - attacker.coords[0]
+    if cc.bridge_index is not None and len(attacker.symbols) > 1:
+        rot = _rotation_between(shifted[1], c.coords[cc.bridge_index] - best_target)
+        shifted = shifted @ rot.T
+    moved = Cluster(
+        name=attacker.name,
+        symbols=list(attacker.symbols),
+        coords=shifted + best_target,
+        charge=attacker.charge,
+        spin=attacker.spin,
+    )
+    ow_index = len(c.symbols)
+    return merge(c, moved, name=f"{c.name}+{attacker.name}"), ow_index

--- a/qm/quarry/pipeline.py
+++ b/qm/quarry/pipeline.py
@@ -161,7 +161,16 @@ class FrequencyResult:
 
 
 def frequencies(cluster: Cluster, settings: DftSettings) -> FrequencyResult:
-    """Analytic Hessian -> projected harmonic analysis (pyscf thermo)."""
+    """Analytic Hessian -> harmonic analysis.
+
+    Free clusters get the standard projected analysis (pyscf thermo).
+    Clusters with ``frozen_indices`` get a partial-Hessian vibrational
+    analysis (PHVA) over the free-atom block instead: no trans/rot
+    projection (the frozen lattice removes those motions) and no
+    rotational temperatures — the embedded cluster does not rotate.
+    Translational terms downstream cancel in any barrier between states
+    of identical composition, which is the only use PHVA results have.
+    """
     from pyscf.hessian import thermo as pyscf_thermo
 
     mf = _make_scf(build_mol(cluster, settings), settings)
@@ -170,6 +179,8 @@ def frequencies(cluster: Cluster, settings: DftSettings) -> FrequencyResult:
         raise RuntimeError(f"SCF did not converge for {cluster.name}")
     hess = mf.Hessian().kernel()
     hess = np.asarray(hess.get() if hasattr(hess, "get") else hess)
+    if cluster.frozen_indices:
+        return _partial_hessian_analysis(cluster, mf, hess, float(e))
     freq_info = pyscf_thermo.harmonic_analysis(mf.mol, hess)
     nu = np.asarray(freq_info["freq_wavenumber"])
     modes = np.asarray(freq_info["norm_mode"])  # (nmodes, natm, 3)
@@ -197,6 +208,50 @@ def frequencies(cluster: Cluster, settings: DftSettings) -> FrequencyResult:
         molar_mass_kg=mass_kg,
         rotational_temperatures_k=rot[0],
         linear=rot[1],
+        imaginary_mode=imag_mode,
+    )
+
+
+def _partial_hessian_analysis(
+    cluster: Cluster, mf: Any, hess: np.ndarray, e: float
+) -> FrequencyResult:
+    """PHVA: diagonalize the mass-weighted free-atom Hessian block."""
+    from pyscf.data import elements, nist
+
+    n = len(cluster.symbols)
+    free = sorted(set(range(n)) - set(cluster.frozen_indices))
+    masses = np.array(
+        [elements.MASSES[elements.charge(cluster.symbols[i])] for i in free]
+    )
+    sub = hess[np.ix_(free, free)]  # (nf, nf, 3, 3)
+    nf = len(free)
+    h = sub.transpose(0, 2, 1, 3).reshape(3 * nf, 3 * nf)
+    h = 0.5 * (h + h.T)
+    inv_sqrt_m = 1.0 / np.sqrt(np.repeat(masses, 3))
+    h_mw = h * np.outer(inv_sqrt_m, inv_sqrt_m)  # Hartree/(Bohr^2 amu)
+    eigvals, eigvecs = np.linalg.eigh(h_mw)
+    # Hartree/(Bohr^2 amu) -> s^-2 -> cm^-1.
+    to_si = nist.HARTREE2J / (nist.ATOMIC_MASS * (nist.BOHR_SI**2))
+    nu_cm = np.sqrt(np.abs(eigvals) * to_si) / (2.0 * np.pi * nist.LIGHT_SPEED_SI * 100)
+    imag_mask = eigvals < 0
+    imag = np.asarray(nu_cm[imag_mask])
+    real = np.asarray(nu_cm[~imag_mask])
+    imag_mode = None
+    if imag.size:
+        idx = np.flatnonzero(imag_mask)[np.argmax(imag)]
+        vec = (eigvecs[:, idx] * inv_sqrt_m).reshape(nf, 3)
+        full = np.zeros((n, 3))
+        full[free] = vec
+        imag_mode = full
+
+    mass_kg = float(np.sum(mf.mol.atom_mass_list())) * 1e-3
+    return FrequencyResult(
+        frequencies_cm=np.sort(real[real > 0]),
+        imaginary_cm=np.sort(imag),
+        electronic_hartree=e,
+        molar_mass_kg=mass_kg,
+        rotational_temperatures_k=None,
+        linear=False,
         imaginary_mode=imag_mode,
     )
 

--- a/qm/quarry/ts.py
+++ b/qm/quarry/ts.py
@@ -108,13 +108,22 @@ def find_ts(
     return replace(cluster, coords=atoms.positions.copy(), name=f"{cluster.name}-ts")
 
 
-def verify_ts(cluster: Cluster, settings: DftSettings) -> FrequencyResult:
-    """Frequency-verify a saddle: exactly one imaginary mode or raise."""
+def verify_ts(
+    cluster: Cluster, settings: DftSettings, *, noise_floor_cm: float = 0.0
+) -> FrequencyResult:
+    """Frequency-verify a saddle: exactly one imaginary mode or raise.
+
+    ``noise_floor_cm`` ignores imaginary modes below the threshold —
+    partial-Hessian analyses on peripherally-frozen clusters can carry a
+    few numerically-imaginary soft modes that are not reaction modes.
+    The default (0) keeps the strict free-cluster behavior.
+    """
     freq = frequencies(cluster, settings)
-    if freq.n_imaginary != 1:
+    significant = freq.imaginary_cm[freq.imaginary_cm > noise_floor_cm]
+    if significant.size != 1:
         raise RuntimeError(
-            f"{cluster.name}: expected exactly 1 imaginary mode, "
-            f"found {freq.n_imaginary} "
+            f"{cluster.name}: expected exactly 1 imaginary mode "
+            f"above {noise_floor_cm:.0f} cm^-1, found {significant.size} "
             f"(imaginary: {np.round(freq.imaginary_cm, 1).tolist()} cm^-1)"
         )
     return freq
@@ -126,13 +135,14 @@ def quick_irc(
     *,
     displacement_a: float = 0.15,
     max_steps: int = 200,
+    noise_floor_cm: float = 0.0,
 ) -> tuple[Cluster, Cluster]:
     """Displace ± along the imaginary mode and relax to the two minima.
 
     The cheap stand-in for a full IRC: confirms which basins the saddle
     connects. Returns (backward, forward) relaxed clusters.
     """
-    freq = verify_ts(ts, settings)
+    freq = verify_ts(ts, settings, noise_floor_cm=noise_floor_cm)
     mode = freq.imaginary_mode
     if mode is None:
         raise RuntimeError(f"{ts.name}: no imaginary-mode vector available")

--- a/qm/scripts/phase2_ladder.py
+++ b/qm/scripts/phase2_ladder.py
@@ -84,6 +84,23 @@ def log(msg: str) -> None:
     print(f"[{time.strftime('%H:%M:%S')}] {msg}", flush=True)
 
 
+def trim_gpu_pool() -> None:
+    """Return CuPy pool blocks to the CUDA driver between stages.
+
+    Multi-hour campaigns otherwise fragment the pool into
+    cudaErrorMemoryAllocation (seen live: stage-2 DF-K gradient OOM
+    right after a 2 h stage-1 optimization on a 24 GB card with ~7 GB
+    resident). No-op without a GPU.
+    """
+    try:
+        import cupy
+
+        cupy.get_default_memory_pool().free_all_blocks()
+        cupy.get_default_pinned_memory_pool().free_all_blocks()
+    except Exception:
+        pass
+
+
 def save_xyz(cluster: Cluster, path: Path) -> None:
     path.write_text(cluster.to_xyz())
 
@@ -199,7 +216,10 @@ def proton_neb_guess(
             fixed_distances=[(m_index, ow_index, pin_a)],
             extend_step_a=0.06,
             min_distance_a=0.95,
-            progress=lambda r, e: log(f"  r(Obr-H)={r:.2f} A  E={e:.6f} Ha"),
+            progress=lambda r, e: (
+                log(f"  r(Obr-H)={r:.2f} A  E={e:.6f} Ha"),
+                trim_gpu_pool(),
+            )[0],
         )
         crest_idx = first_interior_maximum(pscan)
         if crest_idx is None:
@@ -349,6 +369,7 @@ def main() -> int:
     attacker_opt = checkpointed(
         run_dir / "attacker.xyz", attacker, lambda: optimize(attacker, settings)
     )
+    trim_gpu_pool()
 
     # Stage 2 — relaxed approach scan, then the concerted proton route
     # if the approach coordinate alone never crosses the ridge.
@@ -369,7 +390,10 @@ def main() -> int:
                 atom_i=m_index,
                 atom_j=ow_index,
                 distances_a=approach["distances"],
-                progress=lambda r, e: log(f"  r={r:.2f} A  E={e:.6f} Ha"),
+                progress=lambda r, e: (
+                    log(f"  r={r:.2f} A  E={e:.6f} Ha"),
+                    trim_gpu_pool(),
+                )[0],
             )
             ts_guess = scan_ts_guess(scan)
         except ScanNoMaximumError as exc:
@@ -391,6 +415,7 @@ def main() -> int:
             route_path.write_text(route)
 
     # Stage 3 — Sella saddle search with the escaped-channel gates.
+    trim_gpu_pool()
     log("stage 3: Sella saddle search")
     ts_path = run_dir / "ts.xyz"
     trajectory_path = run_dir / "sella.traj"
@@ -434,6 +459,7 @@ def main() -> int:
         return 1
 
     # Stage 4 — verify (PHVA-aware) + quick IRC.
+    trim_gpu_pool()
     log("stage 4: frequencies + quick-IRC")
     ts_freq = frequencies(ts, settings)
     imag = ts_freq.imaginary_cm
@@ -451,6 +477,7 @@ def main() -> int:
 
     # Stage 5 — thermochemistry (PHVA on frozen clusters; trans/rot
     # cancel between complex and TS of identical composition).
+    trim_gpu_pool()
     log("stage 5: thermochemistry")
     cx_freq = frequencies(complex_opt, settings)
     t = args.temperature

--- a/qm/scripts/phase2_ladder.py
+++ b/qm/scripts/phase2_ladder.py
@@ -84,6 +84,26 @@ def log(msg: str) -> None:
     print(f"[{time.strftime('%H:%M:%S')}] {msg}", flush=True)
 
 
+def preload_cutensor() -> None:
+    """Load the cutensor-cu12 wheel's libraries with RTLD_GLOBAL.
+
+    The wheel lands in site-packages/cutensor/lib, which is not on the
+    dynamic loader's path; cupy then silently falls back to its einsum
+    contraction engine, which materializes temporaries that OOM a 24 GB
+    card at ~60 atoms/def2-svp (seen live, twice). Preloading by
+    absolute path makes cupy's dlopen find them regardless of
+    LD_LIBRARY_PATH. Harmless no-op when the wheel is absent (CPU runs).
+    """
+    import contextlib
+    import ctypes
+    import sysconfig
+
+    libdir = Path(sysconfig.get_paths()["purelib"]) / "cutensor" / "lib"
+    for name in ("libcutensor.so.2", "libcutensorMg.so.2"):
+        with contextlib.suppress(OSError):
+            ctypes.CDLL(str(libdir / name), mode=ctypes.RTLD_GLOBAL)
+
+
 def trim_gpu_pool() -> None:
     """Return CuPy pool blocks to the CUDA driver between stages.
 
@@ -300,6 +320,8 @@ def main() -> int:
     args = ap.parse_args()
 
     os.environ.setdefault("OMP_NUM_THREADS", str(args.threads))
+    if args.gpu:
+        preload_cutensor()
     qm_root = Path(__file__).resolve().parent.parent
     deck = Path(args.deck) if args.deck else (
         qm_root.parent / "petra" / "examples" / "kaolinite.toml"

--- a/qm/scripts/phase2_ladder.py
+++ b/qm/scripts/phase2_ladder.py
@@ -1,0 +1,561 @@
+#!/usr/bin/env python
+"""Phase 2: one (family, protonation state, connectivity) ladder cell.
+
+Runs the proven Phase-1 stage machinery on a crystallographic cluster
+cut from the kaolinite deck cell (HANDOFF.md §2b):
+
+    uv run python scripts/phase2_ladder.py --family oss --gpu
+    uv run python scripts/phase2_ladder.py --family oss --n-intact 2 --gpu
+    uv run python scripts/phase2_ladder.py --family oaa --dry-run
+
+Families: oss (300s Si-O-Si), osa (400s Si-O-Al2), oaa (500s Al-OH-Al).
+Each run is one ladder cell: hydrolysis of the center bridge by the
+attacking species, with the attacked metal's connectivity set by
+``--n-intact`` (Q-style: intact bridges, center included). Stages are
+checkpointed as XYZ under runs/phase2/<cell>/ — a crashed campaign
+resumes where it stopped. Frozen-shell clusters get partial-Hessian
+thermochemistry automatically (rot/trans cancel between complex and TS).
+
+``--dry-run`` builds the cluster + attack complex, writes geometry and
+metadata, and exits before any DFT — the sizing step.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import numpy as np  # noqa: E402
+
+from quarry.clusters import Cluster, hydronium, water  # noqa: E402
+from quarry.crystal import attack_complex, from_deck_cell  # noqa: E402
+from quarry.pipeline import (  # noqa: E402
+    HARTREE_TO_KJ,
+    DftSettings,
+    energy,
+    frequencies,
+    optimize,
+)
+from quarry.rates import rate_from_thermo, thermo_from_frequencies  # noqa: E402
+from quarry.store import Store, geometry_hash  # noqa: E402
+from quarry.ts import (  # noqa: E402
+    ScanNoMaximumError,
+    constrained_scan,
+    find_ts,
+    first_interior_maximum,
+    neb_ts_guess,
+    quick_irc,
+    scan_to_maximum,
+    scan_ts_guess,
+)
+
+FAMILIES = {"oss": "Oss", "osa": "Osa", "oaa": "Oaa"}
+STATES = {"neutral": (water, 0), "acid": (hydronium, +1)}
+KCAL = 4.184
+# Imaginary modes below this are PHVA numerical noise, not reaction modes.
+NOISE_FLOOR_CM = 30.0
+# A "barrier" below this is a trivial-rearrangement saddle (learnings).
+MIN_PLAUSIBLE_DE_KJ = 20.0
+# The Phase-1 free-dimer anchor for the lattice-resistance comparison.
+SI_NEUTRAL_FREE_DIMER_DG_KJ = 113.05
+
+# Per-element approach parameters (Angstrom).
+APPROACH = {
+    "Si": {
+        "distances": [2.8, 2.6, 2.4, 2.2, 2.1, 2.0, 1.9],
+        "pin": 1.90,
+        "limit": 2.6,
+    },
+    "Al": {
+        "distances": [3.0, 2.8, 2.6, 2.4, 2.3, 2.2, 2.1, 2.0],
+        "pin": 2.00,
+        "limit": 2.8,
+    },
+}
+
+
+def log(msg: str) -> None:
+    print(f"[{time.strftime('%H:%M:%S')}] {msg}", flush=True)
+
+
+def save_xyz(cluster: Cluster, path: Path) -> None:
+    path.write_text(cluster.to_xyz())
+
+
+def load_xyz(path: Path, template: Cluster) -> Cluster:
+    from dataclasses import replace
+
+    lines = path.read_text().splitlines()
+    n = int(lines[0])
+    coords = np.array(
+        [[float(x) for x in line.split()[1:4]] for line in lines[2 : 2 + n]]
+    )
+    return replace(template, coords=coords)
+
+
+def checkpointed(path: Path, template: Cluster, compute) -> Cluster:
+    if path.exists():
+        log(f"  resume: {path.name} exists, skipping recompute")
+        return load_xyz(path, template)
+    result = compute()
+    save_xyz(result, path)
+    return result
+
+
+def channel_escape_reason(
+    ts_guess: Cluster, ts: Cluster, m_index: int, ow_index: int, limit_a: float
+) -> str | None:
+    r_guess = float(
+        np.linalg.norm(ts_guess.coords[m_index] - ts_guess.coords[ow_index])
+    )
+    r_ts = float(np.linalg.norm(ts.coords[m_index] - ts.coords[ow_index]))
+    if r_ts > limit_a:
+        return f"saddle r(M-Ow)={r_ts:.2f} A is outside the bonding channel"
+    if r_ts > r_guess + 0.5:
+        return f"saddle escaped the approach channel by {r_ts - r_guess:.2f} A"
+    return None
+
+
+def proton_neb_guess(
+    approach_seed: Cluster,
+    complex_opt: Cluster,
+    settings: DftSettings,
+    run_dir: Path,
+    *,
+    m_index: int,
+    br_index: int,
+    ow_index: int,
+    pin_a: float,
+) -> Cluster:
+    """Concerted proton-transfer/product/CI-NEB guess (Phase-1 route,
+    parameterized for arbitrary cluster indices)."""
+    product_path = run_dir / "product.xyz"
+    product_seed: Cluster | None = None
+    h_candidates = [ow_index + 1, ow_index + 2]
+
+    if product_path.exists():
+        product = load_xyz(product_path, approach_seed)
+        r_prod_ow = float(
+            np.linalg.norm(product.coords[m_index] - product.coords[ow_index])
+        )
+        r_prod_br = float(
+            np.linalg.norm(product.coords[m_index] - product.coords[br_index])
+        )
+        log(
+            "  resume: product.xyz exists; "
+            f"r(M-Ow)={r_prod_ow:.2f} A, r(M-Obr)={r_prod_br:.2f} A"
+        )
+        if r_prod_ow <= pin_a and r_prod_br >= 2.2:
+            log("  stage 2d: CI-NEB complex -> product (7 images)")
+            return neb_ts_guess(complex_opt, product, settings)
+        log("  saved product is not hydrolyzed; extending M-Obr cleavage")
+        product_path.replace(run_dir / "product.rejected-rollback.xyz")
+        product_seed = product
+
+    if product_seed is None:
+        seed_r = float(
+            np.linalg.norm(
+                approach_seed.coords[m_index] - approach_seed.coords[ow_index]
+            )
+        )
+        if abs(seed_r - pin_a) > 0.02:
+            log(
+                f"  pinning resumed approach seed: "
+                f"r(M-Ow) {seed_r:.2f} -> {pin_a:.2f} A"
+            )
+            approach_seed = constrained_scan(
+                approach_seed,
+                settings,
+                atom_i=m_index,
+                atom_j=ow_index,
+                distances_a=[pin_a],
+            )[0][2]
+
+        log(f"  stage 2b: pin r(M-Ow)={pin_a:.2f} A, drive H(water) -> O(bridge)")
+        h_idx = min(
+            h_candidates,
+            key=lambda i: np.linalg.norm(
+                approach_seed.coords[i] - approach_seed.coords[br_index]
+            ),
+        )
+        r0 = float(
+            np.linalg.norm(approach_seed.coords[h_idx] - approach_seed.coords[br_index])
+        )
+        log(f"  driving H{h_idx} from r(Obr-H)={r0:.2f} A inward")
+        first = max(1.05, round(r0 - 0.15, 2))
+        distances = [round(float(x), 2) for x in np.arange(first, 1.04, -0.15)]
+        pscan = scan_to_maximum(
+            approach_seed,
+            settings,
+            atom_i=br_index,
+            atom_j=h_idx,
+            distances_a=distances or [first],
+            fixed_distances=[(m_index, ow_index, pin_a)],
+            extend_step_a=0.06,
+            min_distance_a=0.95,
+            progress=lambda r, e: log(f"  r(Obr-H)={r:.2f} A  E={e:.6f} Ha"),
+        )
+        crest_idx = first_interior_maximum(pscan)
+        if crest_idx is None:
+            raise RuntimeError("proton scan produced no interior crest")
+        product_seed = pscan[min(crest_idx + 1, len(pscan) - 1)][2]
+
+    h_idx = min(
+        h_candidates,
+        key=lambda i: np.linalg.norm(
+            product_seed.coords[i] - product_seed.coords[br_index]
+        ),
+    )
+    current_br = float(
+        np.linalg.norm(product_seed.coords[m_index] - product_seed.coords[br_index])
+    )
+    break_targets = [
+        r for r in [1.85, 2.05, 2.30, 2.60, 3.00, 3.40, 3.60] if r > current_br + 0.05
+    ]
+    if not break_targets:
+        break_targets = [round(current_br + 0.30, 2)]
+
+    log("  stage 2c: breaking M-Obr with the new bonds held")
+    broken = constrained_scan(
+        product_seed,
+        settings,
+        atom_i=m_index,
+        atom_j=br_index,
+        distances_a=break_targets,
+        fixed_distances=[
+            (m_index, ow_index, pin_a - 0.20),
+            (br_index, h_idx, 0.98),
+        ],
+    )
+    for r, e, _ in broken:
+        log(f"  r(M-Obr)={r:.2f} A  E={e:.6f} Ha")
+    product = optimize(broken[-1][2], settings)
+    save_xyz(product, product_path)
+
+    r_prod_ow = float(
+        np.linalg.norm(product.coords[m_index] - product.coords[ow_index])
+    )
+    r_prod_br = float(
+        np.linalg.norm(product.coords[m_index] - product.coords[br_index])
+    )
+    log(f"  product r(M-Ow)={r_prod_ow:.2f} A, r(M-Obr)={r_prod_br:.2f} A")
+    if r_prod_ow > pin_a or r_prod_br < 2.2:
+        raise RuntimeError(
+            "product rolled back toward reactants; expected M-Ow bonded "
+            "and M-Obr broken"
+        )
+    log("  stage 2d: CI-NEB complex -> product (7 images)")
+    return neb_ts_guess(complex_opt, product, settings)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--family", choices=sorted(FAMILIES), required=True)
+    ap.add_argument("--state", choices=sorted(STATES), default="neutral")
+    ap.add_argument("--n-intact", type=int, default=None)
+    ap.add_argument("--metal-shells", type=int, default=2)
+    ap.add_argument("--center-index", type=int, default=None)
+    ap.add_argument(
+        "--deck",
+        default=None,
+        help="petra deck carrying the [cell] (default: repo kaolinite.toml)",
+    )
+    ap.add_argument("--xc", default="b3lyp")
+    ap.add_argument("--basis", default="def2-svp")
+    ap.add_argument("--gpu", action="store_true")
+    ap.add_argument("--threads", type=int, default=16)
+    ap.add_argument("--temperature", type=float, default=298.15)
+    ap.add_argument("--dry-run", action="store_true")
+    ap.add_argument(
+        "--run-root",
+        default=None,
+        help="parent of the run dir (default: qm/runs) — tests redirect this",
+    )
+    args = ap.parse_args()
+
+    os.environ.setdefault("OMP_NUM_THREADS", str(args.threads))
+    qm_root = Path(__file__).resolve().parent.parent
+    deck = Path(args.deck) if args.deck else (
+        qm_root.parent / "petra" / "examples" / "kaolinite.toml"
+    )
+    settings = DftSettings(
+        xc=args.xc, basis=args.basis, density_fit=True, use_gpu=args.gpu
+    )
+
+    attacker_factory, charge_offset = STATES[args.state]
+    site_kind = FAMILIES[args.family]
+
+    cc = from_deck_cell(
+        deck,
+        site_kind,
+        center_index=args.center_index,
+        metal_shells=args.metal_shells,
+        n_intact=args.n_intact,
+        target_charge=0,
+    )
+    attacker = attacker_factory()
+    complex_guess, ow_index = attack_complex(cc, attacker)
+    m_index, br_index = cc.attacked_index, cc.bridge_index
+    metal = cc.cluster.symbols[m_index]
+    approach = APPROACH[metal]
+
+    cell_name = f"{args.family}-{args.state}-n{cc.n_intact}-s{cc.metal_shells}"
+    run_root = Path(args.run_root) if args.run_root else qm_root / "runs"
+    run_dir = run_root / "phase2" / f"{cell_name}-{args.xc}-{args.basis}"
+    run_dir.mkdir(parents=True, exist_ok=True)
+    log(f"run dir: {run_dir}")
+    log(f"settings: {settings}")
+    log(
+        f"cell: {cell_name}  cluster {cc.cluster.formula} "
+        f"({len(cc.cluster.symbols)} atoms, {len(cc.cluster.frozen_indices)} frozen, "
+        f"charge {cc.cluster.charge + attacker.charge}), attacked {metal}@{m_index}, "
+        f"bridge O@{br_index}"
+    )
+    for line in cc.termination_log:
+        log(f"  termination: {line}")
+
+    save_xyz(cc.cluster, run_dir / "cluster.xyz")
+    save_xyz(complex_guess, run_dir / "complex_guess.xyz")
+    metadata = cc.metadata()
+    metadata["state"] = args.state
+    metadata["attacker"] = attacker.name
+    metadata["charge_offset"] = charge_offset
+    metadata["deck"] = str(deck)
+    (run_dir / "metadata.json").write_text(json.dumps(metadata, indent=2))
+    if args.dry_run:
+        log("dry run: geometry + metadata written, no DFT")
+        return 0
+
+    # Stage 1 — optimize reactant complex and separated fragments.
+    # Crystallographic positions are sane starting points; no cheap
+    # pre-opt stage (the crude legacy cell is a logged systematic).
+    log("stage 1: optimizing reactant complex + fragments")
+    complex_opt = checkpointed(
+        run_dir / "complex.xyz",
+        complex_guess,
+        lambda: optimize(complex_guess, settings),
+    )
+    cluster_opt = checkpointed(
+        run_dir / "cluster_opt.xyz",
+        cc.cluster,
+        lambda: optimize(cc.cluster, settings),
+    )
+    attacker_opt = checkpointed(
+        run_dir / "attacker.xyz", attacker, lambda: optimize(attacker, settings)
+    )
+
+    # Stage 2 — relaxed approach scan, then the concerted proton route
+    # if the approach coordinate alone never crosses the ridge.
+    log(f"stage 2: relaxed scan r({metal}-Ow), auto-extending to interior maximum")
+    ts_guess_path = run_dir / "ts_guess.xyz"
+    route_path = run_dir / "ts_guess.route"
+    route = route_path.read_text().strip() if route_path.exists() else "direct"
+    if ts_guess_path.exists():
+        ts_guess = load_xyz(ts_guess_path, complex_opt)
+        log(f"  resume: ts_guess.xyz exists ({route} route)")
+    else:
+        route = "direct"
+        route_path.unlink(missing_ok=True)
+        try:
+            scan = scan_to_maximum(
+                complex_opt,
+                settings,
+                atom_i=m_index,
+                atom_j=ow_index,
+                distances_a=approach["distances"],
+                progress=lambda r, e: log(f"  r={r:.2f} A  E={e:.6f} Ha"),
+            )
+            ts_guess = scan_ts_guess(scan)
+        except ScanNoMaximumError as exc:
+            log("  approach coordinate alone does not cross the ridge;")
+            base = min(exc.scan, key=lambda p: abs(p[0] - approach["pin"]))[2]
+            ts_guess = proton_neb_guess(
+                base,
+                complex_opt,
+                settings,
+                run_dir,
+                m_index=m_index,
+                br_index=br_index,
+                ow_index=ow_index,
+                pin_a=approach["pin"],
+            )
+            route = "proton-neb"
+        save_xyz(ts_guess, ts_guess_path)
+        if route == "proton-neb":
+            route_path.write_text(route)
+
+    # Stage 3 — Sella saddle search with the escaped-channel gates.
+    log("stage 3: Sella saddle search")
+    ts_path = run_dir / "ts.xyz"
+    trajectory_path = run_dir / "sella.traj"
+    ts = checkpointed(
+        ts_path,
+        ts_guess,
+        lambda: find_ts(ts_guess, settings, trajectory=str(trajectory_path)),
+    )
+    escape = channel_escape_reason(ts_guess, ts, m_index, ow_index, approach["limit"])
+    if escape and route == "direct":
+        log(f"  !! {escape}; pivoting once to proton-drive + product + CI-NEB")
+        neb_guess = proton_neb_guess(
+            ts_guess,
+            complex_opt,
+            settings,
+            run_dir,
+            m_index=m_index,
+            br_index=br_index,
+            ow_index=ow_index,
+            pin_a=approach["pin"],
+        )
+        if ts_path.exists():
+            ts_path.replace(run_dir / "ts.rejected-direct.xyz")
+        if trajectory_path.exists():
+            trajectory_path.replace(run_dir / "sella.rejected-direct.traj")
+        ts_guess = neb_guess
+        save_xyz(ts_guess, ts_guess_path)
+        route = "proton-neb"
+        route_path.write_text(route)
+        log("stage 3b: Sella saddle search from CI-NEB guess")
+        ts = checkpointed(
+            ts_path,
+            ts_guess,
+            lambda: find_ts(ts_guess, settings, trajectory=str(trajectory_path)),
+        )
+        escape = channel_escape_reason(
+            ts_guess, ts, m_index, ow_index, approach["limit"]
+        )
+    if escape:
+        log(f"  !! {escape}; {route} route exhausted — aborting before thermochemistry")
+        return 1
+
+    # Stage 4 — verify (PHVA-aware) + quick IRC.
+    log("stage 4: frequencies + quick-IRC")
+    ts_freq = frequencies(ts, settings)
+    imag = ts_freq.imaginary_cm
+    significant = imag[imag > NOISE_FLOOR_CM]
+    log(f"  TS imaginary modes: {np.round(imag, 1).tolist()}")
+    if significant.size != 1:
+        log(
+            f"  !! expected exactly 1 imaginary mode above {NOISE_FLOOR_CM:.0f} "
+            f"cm^-1, found {significant.size} — inspect ts.xyz; aborting"
+        )
+        return 1
+    back, fwd = quick_irc(ts, settings, noise_floor_cm=NOISE_FLOOR_CM)
+    save_xyz(back, run_dir / "irc_back.xyz")
+    save_xyz(fwd, run_dir / "irc_fwd.xyz")
+
+    # Stage 5 — thermochemistry (PHVA on frozen clusters; trans/rot
+    # cancel between complex and TS of identical composition).
+    log("stage 5: thermochemistry")
+    cx_freq = frequencies(complex_opt, settings)
+    t = args.temperature
+
+    def thermo(freq):
+        return thermo_from_frequencies(
+            freq.electronic_hartree * HARTREE_TO_KJ,
+            freq.frequencies_cm,
+            t,
+            molar_mass_kg=freq.molar_mass_kg,
+            rotational_temperatures_k=(
+                list(freq.rotational_temperatures_k)
+                if freq.rotational_temperatures_k
+                else None
+            ),
+            linear=freq.linear,
+        )
+
+    rate = rate_from_thermo(
+        thermo(cx_freq),
+        thermo(ts_freq),
+        imag_nu_cm=float(significant[0]),
+        tunneling="wigner",
+    )
+    de_kj = (ts_freq.electronic_hartree - cx_freq.electronic_hartree) * HARTREE_TO_KJ
+    if de_kj < MIN_PLAUSIBLE_DE_KJ:
+        log(
+            f"  !! dE(elec)={de_kj:.1f} kJ/mol is below the trivial-saddle "
+            f"floor ({MIN_PLAUSIBLE_DE_KJ:.0f}) — chemically wrong saddle; aborting"
+        )
+        return 1
+    frag_e = (
+        ts_freq.electronic_hartree
+        - energy(cluster_opt, settings)
+        - energy(attacker_opt, settings)
+    ) * HARTREE_TO_KJ
+
+    results = {
+        "cell": cell_name,
+        "family": args.family,
+        "state": args.state,
+        "n_intact": cc.n_intact,
+        "metal_shells": cc.metal_shells,
+        "attacked_metal": metal,
+        "method": f"{args.xc}/{args.basis}/df",
+        "temperature_k": t,
+        "route": route,
+        "dE_elec_vs_complex_kj": de_kj,
+        "dE_elec_vs_fragments_kj": frag_e,
+        "dH_kj": rate.dh_kj,
+        "dG_kj": rate.dg_kj,
+        "dG_kcal": rate.dg_kj / KCAL,
+        "wigner_kappa": rate.kappa,
+        "k_per_s": rate.k,
+        "ts_imaginary_cm": float(significant[0]),
+        "ts_imaginary_all_cm": [float(x) for x in imag],
+        "cluster": metadata,
+        "geometry_hash": {
+            "complex": geometry_hash(complex_opt.to_xyz()),
+            "ts": geometry_hash(ts.to_xyz()),
+        },
+    }
+    if args.family == "oss" and args.state == "neutral":
+        shift = rate.dg_kj - SI_NEUTRAL_FREE_DIMER_DG_KJ
+        results["lattice_resistance_shift_kj"] = shift
+        log(
+            f"  LATTICE RESISTANCE: dG‡ {rate.dg_kj:.1f} vs free-dimer "
+            f"{SI_NEUTRAL_FREE_DIMER_DG_KJ:.1f} kJ/mol -> shift {shift:+.1f} kJ/mol "
+            "(publishable observable — Pelmenschikov predicts +20 to +70)"
+        )
+    (run_dir / "results.json").write_text(json.dumps(results, indent=2))
+
+    with Store(run_dir / "store.sqlite") as store:
+        for name, cl, freq in (
+            ("complex", complex_opt, cx_freq),
+            ("ts", ts, ts_freq),
+        ):
+            sid = store.add_structure(
+                f"{cell_name}-{name}",
+                cl.formula,
+                cl.to_xyz(),
+                charge=cl.charge,
+                spin=cl.spin,
+            )
+            jid = store.add_job(
+                sid, "freq", results["method"], "gpu4pyscf" if args.gpu else "pyscf"
+            )
+            store.set_job_status(jid, "done")
+            store.add_result(jid, "electronic", freq.electronic_hartree, "hartree")
+
+    log("")
+    log(f"=== {cell_name} @ {results['method']} ===")
+    log(f"  dE(elec, TS - complex)   = {de_kj:8.1f} kJ/mol")
+    log(f"  dH‡({t:.0f})              = {rate.dh_kj:8.1f} kJ/mol")
+    log(
+        f"  dG‡({t:.0f})              = {rate.dg_kj:8.1f} kJ/mol "
+        f"({rate.dg_kj / KCAL:.1f} kcal/mol)"
+    )
+    log(f"  wigner kappa             = {rate.kappa:8.2f}")
+    log(f"  k({t:.0f})                = {rate.k:8.3e} 1/s")
+    log(f"  TS imag mode             = {float(significant[0]):8.1f}i cm^-1")
+    log(f"  dE(elec, TS - fragments) = {frag_e:6.1f} kJ/mol")
+    log(f"results.json + store.sqlite written to {run_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/qm/tests/test_crystal.py
+++ b/qm/tests/test_crystal.py
@@ -1,0 +1,253 @@
+"""Gates for the crystallographic cluster builder (HANDOFF.md §2a).
+
+All CPU-only, no DFT: taxonomy match against the deck cell, termination
+and charge bookkeeping, frozen shell peripheral, no atom collisions,
+cross-check of the deck's crystallography against legacy data.cell.
+"""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from quarry.clusters import SiteFamily, water
+from quarry.crystal import (
+    KIND_TO_FAMILY,
+    DeckCell,
+    attack_complex,
+    from_deck_cell,
+    min_interatomic_distance,
+)
+
+REPO = Path(__file__).resolve().parents[2]
+DECK = REPO / "petra" / "examples" / "kaolinite.toml"
+LEGACY_CELL = REPO / "legacy" / "cpp-model" / "data.cell"
+
+LEGACY_TYPE_TO_KIND = {1: "Al", 2: "Si", 3: "Oss", 4: "Osa", 5: "Oaa"}
+
+
+@pytest.fixture(scope="module")
+def cell() -> DeckCell:
+    return DeckCell.from_deck(DECK)
+
+
+class TestDeckCell:
+    def test_site_census(self, cell):
+        counts: dict[str, int] = {}
+        for s in cell.sites:
+            counts[s.kind] = counts.get(s.kind, 0) + 1
+        assert counts == {"Al": 4, "Si": 4, "Oss": 6, "Osa": 4, "Oaa": 8}
+        assert len(cell.bonds) == 40
+
+    def test_taxonomy_covers_all_kinds(self, cell):
+        assert {s.kind for s in cell.sites} <= set(KIND_TO_FAMILY)
+        assert KIND_TO_FAMILY["Oss"] is SiteFamily.SI_O_SI
+        assert KIND_TO_FAMILY["Osa"] is SiteFamily.SI_O_AL2
+        assert KIND_TO_FAMILY["Oaa"] is SiteFamily.AL_OH_AL
+
+    def test_graph_degrees_are_full_coordination(self, cell):
+        expected = {"Al": 6, "Si": 4, "Oss": 2, "Osa": 3, "Oaa": 2}
+        for i, s in enumerate(cell.sites):
+            assert cell.degree(i) == expected[s.kind], f"site {i} ({s.kind})"
+
+    def test_bond_lengths_sane(self, cell):
+        # Every bonded M-O pair sits at a bondable distance. Bounds are
+        # loose because the dissertation-era cell is crude (1.38-2.73 A
+        # measured — identical in legacy data.cell, so the deck import is
+        # faithful); the pipeline re-optimizes the free region, and the
+        # frozen shell carries this as a documented systematic.
+        for b in cell.bonds:
+            ri = cell.cart((b.i, (0, 0, 0)))
+            rj = cell.cart((b.j, b.dcell))
+            d = float(np.linalg.norm(ri - rj))
+            assert 1.3 < d < 3.0, f"bond {b.i}-{b.j} at {d:.2f} A"
+
+
+def _parse_legacy_cell(path: Path):
+    """(kinds, adjacency) from legacy data.cell; adjacency is per-site
+    sets of (neighbor, dcell). -1 entries are padding."""
+    lines = path.read_text().splitlines()
+    n_sites = int(lines[2].split()[0])
+    kinds: dict[int, str] = {}
+    adj: dict[int, set] = {}
+    current = None
+    for line in lines[3:]:
+        parts = line.split("#")[0].split()
+        if not parts:
+            continue
+        if len(parts) >= 9 or (len(parts) >= 5 and "." in parts[2]):
+            current = int(parts[0])
+            kinds[current] = LEGACY_TYPE_TO_KIND[int(parts[1]) // 100]
+            adj[current] = set()
+            nbr = parts[5:9]
+        else:
+            nbr = parts[:4]
+        if len(nbr) == 4 and current is not None:
+            j = int(nbr[0])
+            if j >= 0:
+                adj[current].add((j, tuple(int(x) for x in nbr[1:4])))
+    assert len(kinds) == n_sites
+    return kinds, adj
+
+
+class TestLegacyCrossCheck:
+    def test_kinds_match_data_cell(self, cell):
+        kinds, _ = _parse_legacy_cell(LEGACY_CELL)
+        assert [cell.sites[i].kind for i in range(len(cell.sites))] == [
+            kinds[i] for i in range(len(kinds))
+        ]
+
+    def test_bond_graph_matches_data_cell(self, cell):
+        _, legacy_adj = _parse_legacy_cell(LEGACY_CELL)
+        deck_adj = {
+            i: {(j, d) for j, d in cell._adjacency[i]} for i in range(len(cell.sites))
+        }
+        assert deck_adj == legacy_adj
+
+
+class TestBuilder:
+    def test_oss_reference_dimer(self):
+        cc = from_deck_cell(DECK, "Oss", metal_shells=1)
+        c = cc.cluster
+        # The crystallographic analog of the X&L disilicate benchmark.
+        assert c.formula == "H6O7Si2"
+        assert c.charge == 0
+        assert cc.bridge_index == 0
+        assert c.symbols[cc.attacked_index] == "Si"
+        assert cc.n_intact == 4  # all four bridges of the attacked Si intact
+        assert not c.frozen_indices  # metal_shells < 2: free cluster
+        assert min_interatomic_distance(c.coords) > 0.75
+        # Bridge O actually bridges: both Si within bonding distance.
+        br = c.coords[cc.bridge_index]
+        si_dists = [
+            np.linalg.norm(c.coords[i] - br)
+            for i, s in enumerate(c.symbols)
+            if s == "Si"
+        ]
+        assert len(si_dists) == 2
+        assert all(1.4 < d < 2.0 for d in si_dists)
+
+    def test_oaa_structural_hydroxyl(self):
+        cc = from_deck_cell(DECK, "Oaa", metal_shells=1)
+        c = cc.cluster
+        assert c.charge == 0
+        br = c.coords[cc.bridge_index]
+        h_dists = [
+            np.linalg.norm(c.coords[i] - br)
+            for i, s in enumerate(c.symbols)
+            if s == "H"
+        ]
+        assert min(h_dists) < 1.1  # the bridging OH proton
+
+    @pytest.mark.parametrize("kind", ["Al", "Si", "Oss", "Osa", "Oaa"])
+    def test_charge_bookkeeping_all_families(self, kind):
+        cc = from_deck_cell(DECK, kind, metal_shells=2)
+        c = cc.cluster
+        q = (
+            4 * sum(1 for s in c.symbols if s == "Si")
+            + 3 * sum(1 for s in c.symbols if s == "Al")
+            - 2 * sum(1 for s in c.symbols if s == "O")
+            + sum(1 for s in c.symbols if s == "H")
+        )
+        assert q == 0 == c.charge
+        assert min_interatomic_distance(c.coords) > 0.75
+
+    def test_target_charge_deprotonation(self):
+        cc = from_deck_cell(DECK, "Oss", metal_shells=1, target_charge=-1)
+        assert cc.cluster.charge == -1
+        assert any("deprotonated" in line for line in cc.termination_log)
+
+    def test_frozen_shell_peripheral(self):
+        cc = from_deck_cell(DECK, "Oss", metal_shells=2)
+        c = cc.cluster
+        assert c.frozen_indices  # lattice resistance present
+        frozen = set(c.frozen_indices)
+        # Reactive center free, and everything bonded to the attacked metal free.
+        assert cc.attacked_index not in frozen
+        assert cc.bridge_index not in frozen
+        m = c.coords[cc.attacked_index]
+        for i, s in enumerate(c.symbols):
+            if s == "O" and np.linalg.norm(c.coords[i] - m) < 2.3:
+                assert i not in frozen
+        # Frozen atoms are exactly the outermost-shell heavy atoms;
+        # protons (constructed guesses, not crystallography) never freeze.
+        assert all(cc.atom_shell[i] == cc.metal_shells for i in frozen)
+        assert all(c.symbols[i] != "H" for i in frozen)
+        # And they are geometrically peripheral.
+        center = c.coords[cc.bridge_index]
+        d_frozen = [np.linalg.norm(c.coords[i] - center) for i in frozen]
+        d_free_metal = [
+            np.linalg.norm(c.coords[i] - center)
+            for i in range(len(c.symbols))
+            if i not in frozen and c.symbols[i] in ("Si", "Al")
+        ]
+        assert np.mean(d_frozen) > np.mean(d_free_metal)
+
+    def test_n_intact_ladder_on_si(self):
+        # Q-style connectivity rungs on the Si under attack (Oss center).
+        for n in (1, 2, 3, 4):
+            cc = from_deck_cell(DECK, "Oss", metal_shells=2, n_intact=n)
+            c = cc.cluster
+            assert cc.n_intact == n
+            assert c.charge == 0
+            assert min_interatomic_distance(c.coords) > 0.75
+            # Attacked Si keeps full O coordination: pruned bridges
+            # became terminal hydroxyls, not vacancies.
+            # Thresholds sized to the crude legacy cell (bonds 1.4-2.8 A,
+            # next-nearest O at 2.8+).
+            m = c.coords[cc.attacked_index]
+            o_near = [
+                i
+                for i, s in enumerate(c.symbols)
+                if s == "O" and np.linalg.norm(c.coords[i] - m) < 2.3
+            ]
+            assert len(o_near) == 4
+            # Exactly n of those oxygens still bridge to another metal.
+            bridging = 0
+            for i in o_near:
+                other = [
+                    j
+                    for j, s in enumerate(c.symbols)
+                    if s in ("Si", "Al")
+                    and j != cc.attacked_index
+                    and np.linalg.norm(c.coords[j] - c.coords[i]) < 2.8
+                ]
+                bridging += bool(other)
+            assert bridging == n
+
+    def test_pruning_shrinks_cluster(self):
+        full = from_deck_cell(DECK, "Oss", metal_shells=2)
+        pruned = from_deck_cell(DECK, "Oss", metal_shells=2, n_intact=1)
+        n_si = lambda cc: sum(1 for s in cc.cluster.symbols if s == "Si")  # noqa: E731
+        assert n_si(pruned) < n_si(full)
+
+    @pytest.mark.parametrize("kind", ["Oss", "Osa", "Oaa"])
+    def test_default_size_in_survey_window(self, kind):
+        cc = from_deck_cell(DECK, kind, metal_shells=2)
+        n_centers = sum(1 for s in cc.cluster.symbols if s in ("Si", "Al"))
+        assert 4 <= n_centers <= 30
+        assert 20 <= len(cc.cluster.symbols) <= 160
+
+    def test_metal_center_family(self):
+        cc = from_deck_cell(DECK, "Si", metal_shells=2)
+        c = cc.cluster
+        assert cc.bridge_index is None
+        assert c.symbols[cc.attacked_index] == "Si"
+        assert cc.atom_shell[cc.attacked_index] == 0
+        assert c.charge == 0
+
+
+class TestAttackComplex:
+    def test_water_attack_on_oss(self):
+        cc = from_deck_cell(DECK, "Oss", metal_shells=2)
+        complex_, ow = attack_complex(cc, water())
+        n0 = len(cc.cluster.symbols)
+        assert ow == n0
+        assert len(complex_.symbols) == n0 + 3
+        assert complex_.symbols[ow] == "O"
+        # Attacker O at the approach distance from the attacked metal.
+        d = np.linalg.norm(complex_.coords[ow] - complex_.coords[cc.attacked_index])
+        assert d == pytest.approx(3.2, abs=0.05)
+        # Frozen shell carried through the merge untouched.
+        assert complex_.frozen_indices == cc.cluster.frozen_indices
+        assert min_interatomic_distance(complex_.coords) > 0.75

--- a/qm/tests/test_phase2_driver.py
+++ b/qm/tests/test_phase2_driver.py
@@ -1,0 +1,73 @@
+"""Fast orchestration gates for the Phase-2 ladder driver (no DFT)."""
+
+import json
+import sys
+
+import numpy as np
+import pytest
+
+from quarry.clusters import Cluster
+from scripts import phase2_ladder as phase2
+
+
+def geometry(name: str, m_ow: float, m_obr: float = 1.6) -> Cluster:
+    return Cluster(
+        name=name,
+        symbols=["O", "Si", "O", "H", "H"],
+        coords=np.array(
+            [
+                [m_obr, 0.0, 0.0],
+                [0.0, 0.0, 0.0],
+                [m_ow, 0.0, 0.0],
+                [m_ow, 0.9, 0.0],
+                [m_ow, -0.9, 0.0],
+            ]
+        ),
+    )
+
+
+def test_channel_escape_guard_uses_metal_limit():
+    guess = geometry("guess", 2.2)
+    # Outside the Si channel (limit 2.6) but inside the Al channel (2.8).
+    drifted = geometry("drift", 2.7)
+    assert phase2.channel_escape_reason(guess, drifted, 1, 2, 2.6) is not None
+    assert phase2.channel_escape_reason(guess, drifted, 1, 2, 2.8) is None
+    # Relative escape trips regardless of the absolute limit.
+    rel = phase2.channel_escape_reason(
+        geometry("g", 1.8), geometry("d", 2.4), 1, 2, 2.8
+    )
+    assert rel is not None and "escaped" in rel
+
+
+@pytest.mark.parametrize("family", ["oss", "osa", "oaa"])
+def test_dry_run_writes_geometry_and_metadata(family, tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "phase2_ladder.py",
+            "--family",
+            family,
+            "--dry-run",
+            "--run-root",
+            str(tmp_path),
+        ],
+    )
+    assert phase2.main() == 0
+    candidates = sorted((tmp_path / "phase2").glob(f"{family}-neutral-*"))
+    assert candidates, "dry run produced no run dir"
+    run_dir = candidates[-1]
+    meta = json.loads((run_dir / "metadata.json").read_text())
+    assert meta["state"] == "neutral"
+    assert meta["charge"] == 0
+    assert meta["n_frozen"] > 0
+    assert (run_dir / "cluster.xyz").exists()
+    assert (run_dir / "complex_guess.xyz").exists()
+
+
+def test_approach_parameters_cover_both_metals():
+    assert phase2.APPROACH["Si"]["pin"] == pytest.approx(1.90)
+    assert phase2.APPROACH["Al"]["pin"] == pytest.approx(2.00)
+    for p in phase2.APPROACH.values():
+        assert p["limit"] > p["pin"]
+        assert min(p["distances"]) >= p["pin"]

--- a/qm/tests/test_pipeline.py
+++ b/qm/tests/test_pipeline.py
@@ -129,3 +129,45 @@ class TestThermoCrossCheck:
         assert ours.entropy_kj_per_k == pytest.approx(
             val("S_tot") * hartree_to_kj, rel=1e-3
         )
+
+
+class TestPartialHessian:
+    """PHVA path: frequencies() on a cluster with frozen_indices."""
+
+    def test_phva_mode_count_and_stretches(self, opt_water):
+        from dataclasses import replace
+
+        # Freeze the oxygen: 2 free H -> 6 PHVA modes, no trans/rot
+        # projection, no rotational temperatures.
+        frozen = replace(opt_water, frozen_indices=[0])
+        freq = frequencies(frozen, CHEAP)
+        total = freq.frequencies_cm.size + freq.imaginary_cm.size
+        assert total == 6
+        assert freq.rotational_temperatures_k is None
+        # The OH stretches and the bend survive the freeze.
+        assert np.sum(freq.frequencies_cm > 1500) >= 3
+        # Residual imaginary modes are pure rotation-about-O noise.
+        assert np.all(freq.imaginary_cm < 100)
+
+    def test_phva_energy_matches_full(self, opt_water):
+        from dataclasses import replace
+
+        e_full = frequencies(opt_water, CHEAP).electronic_hartree
+        frozen = replace(opt_water, frozen_indices=[0])
+        e_phva = frequencies(frozen, CHEAP).electronic_hartree
+        assert e_phva == pytest.approx(e_full, abs=1e-8)
+
+    def test_phva_imaginary_mode_zero_on_frozen_atoms(self, opt_water):
+        from dataclasses import replace
+
+        # Displace one H off the minimum so a real imaginary mode exists,
+        # then check the returned mode vector is zero on the frozen atom.
+        bent = replace(
+            opt_water,
+            coords=opt_water.coords
+            + np.array([[0, 0, 0], [0.4, -0.3, 0.2], [0, 0, 0]]),
+            frozen_indices=[0],
+        )
+        freq = frequencies(bent, CHEAP)
+        if freq.imaginary_mode is not None:
+            assert np.allclose(freq.imaginary_mode[0], 0.0)


### PR DESCRIPTION
## Summary

Platform half of card A3-barrier-ladder (qm/HANDOFF.md Phase 2 §2a/§2b):

- **`qm/quarry/crystal.py`** — crystallographic cluster builder. Parses the petra deck `[cell]` (frac→Cartesian with lattice vectors as columns, per petra-core crystal.rs; lazy periodic bond graph from the `dcell` offsets). `from_deck_cell()` cuts terminated, peripherally-frozen clusters per KMC site family: Pauling bond-valence proton placement and charge bookkeeping (Si–O 1.0, Al–O 0.5, structural H on Oaa), Q-style `n_intact` connectivity pruning with dissolved-partner semantics (edge-sharing octahedra cascade; unprunable center partners logged as DEVIATION), outermost-metal-shell freezing (heavy atoms only — constructed protons never freeze). `attack_complex()` places the attacker with a clearance-searched flank geometry.
- **PHVA** — `pipeline.frequencies()` now runs a partial-Hessian vibrational analysis over free atoms when `frozen_indices` is set (no trans/rot projection, no rotational temperatures); `verify_ts`/`quick_irc` gain an optional noise floor for PHVA soft modes. Trans terms cancel in complex→TS barriers (identical composition).
- **`qm/scripts/phase2_ladder.py`** — one ladder cell (family × protonation × connectivity) end-to-end with the proven Phase-1 stage machinery: checkpointed/resumable, metal-aware approach parameters (Si pin 1.90 Å / Al 2.00 Å), `--dry-run` sizing mode, trivial-saddle floor gate, lattice-resistance shift logged against the si-neutral free-dimer anchor (113.05 kJ/mol).
- **GPU campaign robustness, both measured live on the pilot**: CuPy pool trimming at stage boundaries (fragmentation OOM after a 2 h stage), and a cutensor-cu12 preload (the wheel is invisible to the loader; the cupy einsum fallback OOMs a 24 GB card at ~60 atoms — cuTENSOR is feasibility, not just speed). Learnings updated.
- **Bookkeeping per PROTOCOL**: card claimed + Progress log, STATUS.md line, learnings (crude legacy cell crystallography is a frozen-shell systematic — bonds 1.38–2.88 Å, faithful to data.cell).

Pilot cell `oss-neutral-n4-s2` (Si₆Al₃O₂₉H₂₅ + H₂O, 63 atoms, 29 frozen) is running on the workstation GPU; barrier numbers land in per-family PRs with CALCULATIONS.md updates, per the card.

## Test plan

- 27 new CPU-only gates in `tests/test_crystal.py` (site census, full-coordination degrees, **legacy data.cell cross-check of kinds + all 40 bonds with image offsets**, termination/charge bookkeeping for all 5 families, target-charge deprotonation, frozen-shell peripherality, n_intact ladder 1–4 with Q-coordination checks, attack-complex geometry) + PHVA gates in `test_pipeline.py` + driver gates in `test_phase2_driver.py` (dry-run per family, channel-escape limits).
- Full fast suite: 122 passed. `ruff check` clean.

## Breaking changes

None. `frequencies()` behavior changes only for clusters with `frozen_indices` (previously produced physically wrong projected analyses for those); free clusters are byte-identical paths.

## Summary by Sourcery

Enable Phase 2 crystallographic barrier-ladder campaigns with physically appropriate frozen-cluster vibrational analysis and robust resumable GPU execution.

New Features:
- Add crystallographic cluster construction from Petra deck cells with termination, charge balancing, connectivity pruning, and peripheral frozen-shell support.
- Add a resumable Phase 2 ladder driver for family, protonation, and connectivity campaigns, including dry-run geometry generation and thermochemical result storage.

Bug Fixes:
- Use partial-Hessian vibrational analysis for frozen clusters without inappropriate translational or rotational projection.
- Filter low-frequency PHVA imaginary modes when verifying transition states and running quick IRC checks.

Enhancements:
- Add metal-specific approach geometry, channel-escape safeguards, trivial-saddle rejection, and lattice-resistance comparison for ladder campaigns.
- Improve GPU campaign reliability by preloading cuTENSOR and trimming CuPy memory pools between stages.

Documentation:
- Record Phase 2 campaign progress, crystallographic-cell limitations, and GPU execution learnings.

Tests:
- Add CPU-only coverage for deck-cell parsing, crystallographic topology, termination and charge bookkeeping, connectivity ladders, frozen shells, attack complexes, PHVA behavior, and driver dry runs.