### PR TITLE
fix(qm): validate deck cell matrix in DeckCell

### DIFF
--- a/qm/quarry/crystal.py
+++ b/qm/quarry/crystal.py
@@ -77,6 +77,16 @@ class DeckCell:
     )
 
     def __post_init__(self) -> None:
+        matrix = np.asarray(self.matrix, dtype=float)
+        if matrix.shape != (3, 3):
+            raise ValueError(f"deck cell matrix must be 3x3, got {matrix.shape}")
+        if not np.all(np.isfinite(matrix)):
+            raise ValueError("deck cell matrix must be finite")
+        if abs(float(np.linalg.det(matrix))) < 1e-12:
+            raise ValueError(
+                "deck cell lattice vectors are degenerate (zero cell volume)"
+            )
+        self.matrix = matrix
         unknown = {s.kind for s in self.sites} - set(KIND_TO_FAMILY)
         if unknown:
             raise ValueError(f"unknown site kinds in deck cell: {sorted(unknown)}")

--- a/qm/tests/test_crystal.py
+++ b/qm/tests/test_crystal.py
@@ -62,6 +62,36 @@ class TestDeckCell:
             d = float(np.linalg.norm(ri - rj))
             assert 1.3 < d < 3.0, f"bond {b.i}-{b.j} at {d:.2f} A"
 
+    def test_matrix_is_normalized_3x3(self, cell):
+        assert cell.matrix.shape == (3, 3)
+        assert np.issubdtype(cell.matrix.dtype, np.floating)
+        assert np.all(np.isfinite(cell.matrix))
+
+    def test_matrix_rejects_wrong_shape(self):
+        with pytest.raises(ValueError, match="3x3"):
+            DeckCell(matrix=[[1.0, 0.0, 0.0]], sites=[], bonds=[])
+
+    def test_matrix_rejects_degenerate_vectors(self):
+        # Two identical lattice vectors -> zero cell volume.
+        with pytest.raises(ValueError, match="degenerate"):
+            DeckCell(
+                matrix=[[1.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 1.0]],
+                sites=[],
+                bonds=[],
+            )
+
+    def test_matrix_rejects_nonfinite(self):
+        with pytest.raises(ValueError, match="finite"):
+            DeckCell(
+                matrix=[
+                    [1.0, 0.0, 0.0],
+                    [0.0, float("nan"), 0.0],
+                    [0.0, 0.0, 1.0],
+                ],
+                sites=[],
+                bonds=[],
+            )
+
 
 def _parse_legacy_cell(path: Path):
     """(kinds, adjacency) from legacy data.cell; adjacency is per-site


### PR DESCRIPTION
Follow-up to #37 (Sourcery review).

## What
`DeckCell.__post_init__` now validates the `[cell].matrix` before use:
- shape must be 3×3
- entries must be finite
- lattice vectors must be non-degenerate (non-zero cell volume)

Malformed/mismatched deck cells now fail fast instead of propagating subtle geometry issues into cluster construction.

## Notes
- The other Sourcery comment (`frozen_indices` range validation in `_partial_hessian_analysis`) is already covered by `Cluster.__post_init__` (clusters.py), which rejects out-of-range frozen indices at construction — no change needed.
- Adds 4 gate tests in `tests/test_crystal.py` (normalized 3×3, wrong shape, degenerate vectors, non-finite entries).

## Verification
- `pytest tests/test_crystal.py`: 26 passed
- `ruff check`: clean

## Summary by Sourcery

Validate deck cell matrices before using them in geometry construction.

Bug Fixes:
- Validate DeckCell matrices at construction so malformed geometry fails fast instead of propagating into cluster construction.

Enhancements:
- Normalize accepted deck cell matrices to floating-point 3×3 arrays and reject non-finite or degenerate lattice vectors.

Tests:
- Add coverage for valid normalized matrices and invalid shape, degenerate-volume, and non-finite matrix inputs.