### PR TITLE
fix(qm): include frozen_indices in geometry fingerprint; share imaginary-mode check

### DIFF
--- a/qm/quarry/pipeline.py
+++ b/qm/quarry/pipeline.py
@@ -166,12 +166,19 @@ class FrequencyResult:
 
 
 def frequency_geometry_fingerprint(cluster: Cluster) -> str:
-    """Exact geometry/electronic-state identity for reusable Hessian results."""
+    """Exact geometry/electronic-state identity for reusable Hessian results.
+
+    Includes the frozen-atom set: PHVA (partial Hessian) and TS verification
+    depend on which atoms are frozen, so a Hessian computed with a different
+    frozen set must never be reused for this geometry.
+    """
     digest = hashlib.sha256()
     digest.update("\0".join(cluster.symbols).encode())
     digest.update(f"\0{cluster.charge}\0{cluster.spin}\0".encode())
     coords = np.ascontiguousarray(cluster.coords, dtype="<f8")
     digest.update(coords.tobytes())
+    frozen = ",".join(str(i) for i in sorted(cluster.frozen_indices))
+    digest.update(f"\0frozen:{frozen}\0".encode())
     return digest.hexdigest()
 
 

--- a/qm/quarry/ts.py
+++ b/qm/quarry/ts.py
@@ -198,6 +198,24 @@ def find_ts(
     return replace(cluster, coords=atoms.positions.copy(), name=f"{cluster.name}-ts")
 
 
+def _require_single_imaginary_mode(
+    freq: FrequencyResult, *, name: str, noise_floor_cm: float
+) -> None:
+    """Raise unless exactly one imaginary mode clears the noise floor.
+
+    Shared by :func:`verify_ts` and the precomputed-``FrequencyResult`` path
+    in :func:`quick_irc` so the reuse path cannot drift from the main TS
+    verification behavior.
+    """
+    significant = freq.imaginary_cm[freq.imaginary_cm > noise_floor_cm]
+    if significant.size != 1:
+        raise RuntimeError(
+            f"{name}: expected exactly 1 imaginary mode "
+            f"above {noise_floor_cm:.0f} cm^-1, found {significant.size} "
+            f"(imaginary: {np.round(freq.imaginary_cm, 1).tolist()} cm^-1)"
+        )
+
+
 def verify_ts(
     cluster: Cluster, settings: DftSettings, *, noise_floor_cm: float = 0.0
 ) -> FrequencyResult:
@@ -209,13 +227,9 @@ def verify_ts(
     The default (0) keeps the strict free-cluster behavior.
     """
     freq = frequencies(cluster, settings)
-    significant = freq.imaginary_cm[freq.imaginary_cm > noise_floor_cm]
-    if significant.size != 1:
-        raise RuntimeError(
-            f"{cluster.name}: expected exactly 1 imaginary mode "
-            f"above {noise_floor_cm:.0f} cm^-1, found {significant.size} "
-            f"(imaginary: {np.round(freq.imaginary_cm, 1).tolist()} cm^-1)"
-        )
+    _require_single_imaginary_mode(
+        freq, name=cluster.name, noise_floor_cm=noise_floor_cm
+    )
     return freq
 
 
@@ -243,12 +257,9 @@ def quick_irc(
             raise ValueError("precomputed frequency belongs to a different geometry")
         if freq.settings_fingerprint != frequency_settings_fingerprint(settings):
             raise ValueError("precomputed frequency used different DFT settings")
-        significant = freq.imaginary_cm[freq.imaginary_cm > noise_floor_cm]
-        if significant.size != 1:
-            raise RuntimeError(
-                f"{ts.name}: expected exactly 1 imaginary mode "
-                f"above {noise_floor_cm:.0f} cm^-1, found {significant.size}"
-            )
+        _require_single_imaginary_mode(
+            freq, name=ts.name, noise_floor_cm=noise_floor_cm
+        )
     mode = freq.imaginary_mode
     if mode is None:
         raise RuntimeError(f"{ts.name}: no imaginary-mode vector available")

--- a/qm/tests/test_pipeline.py
+++ b/qm/tests/test_pipeline.py
@@ -59,6 +59,27 @@ def test_frequency_geometry_fingerprint_is_exact_identity():
     assert frequency_geometry_fingerprint(charged) != base_fp
 
 
+def test_frequency_geometry_fingerprint_includes_frozen_indices():
+    """The frozen-atom set is part of the geometry identity.
+
+    PHVA (partial Hessian) and TS verification branch on ``frozen_indices``,
+    so a Hessian computed with a different frozen set must never be reused
+    for the same coordinates.
+    """
+    from dataclasses import replace
+
+    base = water()
+    frozen = replace(base, frozen_indices=[0])
+
+    assert frequency_geometry_fingerprint(frozen) != frequency_geometry_fingerprint(
+        base
+    )
+    # Order-independent: the frozen set is sorted before hashing.
+    assert frequency_geometry_fingerprint(
+        replace(base, frozen_indices=[0, 1])
+    ) == frequency_geometry_fingerprint(replace(base, frozen_indices=[1, 0]))
+
+
 def test_gpu_hessian_assertion_retries_only_hessian_on_cpu(monkeypatch):
     calls = []
 


### PR DESCRIPTION
Follow-up to #40 (merged before these source fixes landed).

Addresses Sourcery high-level feedback:

1. **`frequency_geometry_fingerprint` now hashes `frozen_indices`.** PHVA/partial-Hessian and TS verification branch on which atoms are frozen, so a Hessian computed with a different frozen set must never be reused for the same coordinates.
2. **Extract `_require_single_imaginary_mode`** shared by `verify_ts` and the precomputed-`FrequencyResult` path in `quick_irc`, so the reuse path cannot drift from the main TS verification behavior.

Also adds `test_frequency_geometry_fingerprint_includes_frozen_indices` (order-independent frozen-set hashing).

Note: Sourcery's suggested translation/rotation-invariance test was intentionally not applied — the geometry fingerprint is an exact-identity cache key (raw coordinate bytes), not a rigid-motion-invariant descriptor.

## Summary by Sourcery

Ensure Hessian cache identities include frozen atoms and unify transition-state imaginary-mode validation across frequency reuse paths.

Bug Fixes:
- Prevent reuse of Hessian results when the set of frozen atoms differs, while treating frozen-index ordering consistently.
- Keep transition-state imaginary-mode validation consistent between direct verification and precomputed-frequency IRC paths.

Enhancements:
- Centralize validation of exactly one significant imaginary mode for transition-state checks.

Tests:
- Add coverage confirming frozen indices affect geometry fingerprints and that their ordering is ignored.