### PR TITLE
docs: card QI2-gpu-lease — GPU lane lease + VRAM headroom

### DIFF
--- a/docs/program/PLAN.md
+++ b/docs/program/PLAN.md
@@ -28,6 +28,7 @@ on main). Priority P0 > P1 > P2 within READY.
 | [B1-schema-rfc](cards/B1-schema-rfc.md) | B | P0 | any | done | — |
 | [B2-engine-refactor](cards/B2-engine-refactor.md) | B | P0 | any | ready | B1 ✅ |
 | [QI1-driver-enforced-etiquette](cards/QI1-driver-enforced-etiquette.md) | A | P2 | any | ready | — |
+| [QI2-gpu-lease](cards/QI2-gpu-lease.md) | A | P1 | any | ready | — |
 | [E1-muscovite-deck](cards/E1-muscovite-deck.md) | E | P1 | any | ready | — (phase 1 isothermal) |
 | [A1b-acid-mechanisms](cards/A1b-acid-mechanisms.md) | A | P1 | workstation | ready | — |
 | [A3-barrier-ladder](cards/A3-barrier-ladder.md) | A | P1 | workstation | ready | — |

--- a/docs/program/STATUS.md
+++ b/docs/program/STATUS.md
@@ -66,3 +66,8 @@ Deviations get a `DEVIATION:` note; details live in the card.*
   tasks; omnibus-supervisor Hermes cron (daily 07:50) does bookkeeping
   + stale claims + Telegram digest. PROTOCOL.md amended. Humans and
   Fable are now exception handlers, not schedulers.
+- 2026-08-20 — fable — card QI2-gpu-lease (READY, P1): explicit
+  single-lane GPU lease + 16 GB cupy cap + shared worker preflight,
+  after reviewing overnight A3-pilot/ollama cohabitation (22 ollama
+  loads, all-GPU, zero errors — but pilot peaked 21.7 GB; luck, not
+  design) and TASK-168's per-tick hand-rolled preflights.

--- a/docs/program/cards/QI2-gpu-lease.md
+++ b/docs/program/cards/QI2-gpu-lease.md
@@ -1,0 +1,46 @@
+# QI2-gpu-lease — single-lane GPU lease + VRAM headroom for cohabiting services
+
+- status: ready
+- track: A (quality/infrastructure)
+- priority: P1
+- machine: any (implementation + mocked tests; live verification needs workstation)
+- depends: —
+- claimed-by:
+
+## Objective
+The RTX 4090 is shared: quarry DFT campaigns (10–22 GB, spiky), ollama
+(email-poc pipeline + other local-model users, small models loaded on
+demand), and occasional container jobs. Overnight 2026-08-19/20 the A3
+pilot and ollama coexisted only by luck (pilot peaks hit 21.7 GB; ollama
+models happened to be small), and queue workers serialized via ad-hoc
+hand-rolled nvidia-smi preflights re-implemented per task (see
+mission-control TASK-168 progress log). Make the lane explicit:
+
+1. `qm/quarry/etiquette.py` (or extend QI1's module if it lands first):
+   `acquire_gpu(owner, expected_gb, ttl_hours)` — file lease under
+   `~/.local/state/gpu-lease/lease.json` (owner, pid, started, ttl,
+   expected_gb). Stale detection: lease pid dead → break with a dated
+   note. Refuse to acquire when a live lease exists; drivers exit with
+   a clear "GPU lane busy (owner=X)" message instead of contending.
+2. VRAM headroom: leased DFT processes set a cupy memory-pool limit
+   (default 16 GB, `--gpu-mem-gb` override) so ollama always has ≥6 GB
+   to land models in. Document the floor in qm/README.md.
+3. Shared preflight for queue workers: `scripts/gpu_preflight.sh`
+   (repo) that checks the lease + nvidia-smi and exits 0/1 — replaces
+   each worker's hand-rolled check; reference it from the TASK-168
+   family and future campaign cards.
+4. Wire `phase2_ladder.py` and `phase1_xiao_lasaga.py` to acquire the
+   lease at start and release on exit (context manager; release on
+   SIGTERM too).
+
+## Acceptance
+- Unit tests (mocked filesystem/pid) for acquire/refuse/stale-break;
+  ruff + suite green.
+- Both campaign drivers take/release the lease; running a second
+  driver while one holds it exits non-zero with the busy message.
+- cupy pool limit verifiably applied (test may mock cupy).
+- qm/README.md documents the lane rules + ollama floor.
+
+## Progress
+- 2026-08-20 — card created (fable) after reviewing the overnight
+  A3-pilot/ollama cohabitation and the TASK-168 preflight churn.

--- a/docs/program/cards/QI2-gpu-lease.md
+++ b/docs/program/cards/QI2-gpu-lease.md
@@ -22,7 +22,7 @@ mission-control TASK-168 progress log). Make the lane explicit:
    expected_gb). Stale detection: lease pid dead → break with a dated
    note. Refuse to acquire when a live lease exists; drivers exit with
    a clear "GPU lane busy (owner=X)" message instead of contending.
-2. VRAM headroom: leased DFT processes set a cupy memory-pool limit
+2. VRAM headroom: leased DFT processes set a CuPy memory-pool limit
    (default 16 GB, `--gpu-mem-gb` override) so ollama always has ≥6 GB
    to land models in. Document the floor in qm/README.md.
 3. Shared preflight for queue workers: `scripts/gpu_preflight.sh`


### PR DESCRIPTION
## Summary
- New READY P1 card: explicit single-lane GPU lease (file lease, stale-break), 16 GB cupy memory-pool cap for DFT so ollama keeps a ≥6 GB floor, shared `gpu_preflight.sh` replacing per-task hand-rolled checks, campaign drivers wired to acquire/release.
- Motivated by overnight A3-pilot/ollama cohabitation (worked, but by luck — pilot peaked 21.7 GB) and TASK-168's preflight churn.

## Test plan
Docs-only; card format per PROTOCOL.md.

## Breaking changes
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Define a coordinated GPU resource policy to enable reliable cohabitation of DFT campaigns, ollama, and other GPU workloads.

New Features:
- Add a READY P1 quality/infrastructure card defining exclusive GPU leasing, VRAM headroom, shared preflight checks, and campaign-driver integration.

Enhancements:
- Record the GPU cohabitation risk and standardize the planned safeguards for shared GPU workloads.

Documentation:
- Document the QI2 GPU lease card in the program plan and status, including acceptance criteria and operational constraints.