### PR TITLE
docs: CuPy capitalization in QI2-gpu-lease card

### DIFF
--- a/docs/program/cards/QI2-gpu-lease.md
+++ b/docs/program/cards/QI2-gpu-lease.md
@@ -38,7 +38,7 @@ mission-control TASK-168 progress log). Make the lane explicit:
   ruff + suite green.
 - Both campaign drivers take/release the lease; running a second
   driver while one holds it exits non-zero with the busy message.
-- cupy pool limit verifiably applied (test may mock cupy).
+- CuPy pool limit verifiably applied (test may mock CuPy).
 - qm/README.md documents the lane rules + ollama floor.
 
 ## Progress


### PR DESCRIPTION
Follow-up to #44 (merged before the Sourcery nitpick fix landed).

## Summary
- Fixes lowercase `cupy` → `CuPy` on the Acceptance line of `docs/program/cards/QI2-gpu-lease.md` (library name styling), addressing the Sourcery nitpick thread on #44.

## Test plan
Docs-only; card format per PROTOCOL.md.

## Breaking changes
None.

## Summary by Sourcery

Documentation:
- Correct the CuPy library name capitalization in the QI2 GPU lease card.