### PR TITLE
fix(petra): close E1 merged-main lint gate

### DIFF
--- a/docs/program/STATUS.md
+++ b/docs/program/STATUS.md
@@ -6,8 +6,8 @@ Deviations get a `DEVIATION:` note; details live in the card.*
 
 - 2026-08-20 — hermes-workstation — E1 merged-main closeout: removed four
   default-Ruff E731 violations from the muscovite SVG post-processor with
-  typed local helpers; output-equivalence and full E1 acceptance are the
-  follow-up gate.
+  typed local helpers, cleared current Clippy findings, and reverified both
+  full trajectories plus byte-identical CSV/SVG/JSON products.
 - 2026-08-20 — hermes-workstation — E1-muscovite-deck done: schema-v1
   500/700 °C paired-OH + divacancy decks, Hames–Bowring cylinder `D/a²`
   inversion, reproducible CSV/SVG/JSON products, and qualitative gates green

--- a/docs/program/STATUS.md
+++ b/docs/program/STATUS.md
@@ -4,6 +4,10 @@
 appended by the PR that did it: `date — actor — what + pointer`.
 Deviations get a `DEVIATION:` note; details live in the card.*
 
+- 2026-08-20 — hermes-workstation — E1 merged-main closeout: removed four
+  default-Ruff E731 violations from the muscovite SVG post-processor with
+  typed local helpers; output-equivalence and full E1 acceptance are the
+  follow-up gate.
 - 2026-08-20 — hermes-workstation — E1-muscovite-deck done: schema-v1
   500/700 °C paired-OH + divacancy decks, Hames–Bowring cylinder `D/a²`
   inversion, reproducible CSV/SVG/JSON products, and qualitative gates green

--- a/docs/program/cards/E1-muscovite-deck.md
+++ b/docs/program/cards/E1-muscovite-deck.md
@@ -46,6 +46,14 @@ kinds, rules, and barrier provenance (§4 table).
   with typed nested functions without changing output; the full Petra suite,
   focused post-processing tests, Ruff, and regenerated-result equivalence are
   the follow-up gate.
+- 2026-08-20 — hermes-workstation — follow-up gate PASS: 42 Rust tests and
+  10 focused Python tests passed; current Rust Clippy (`-D warnings`) and
+  Python Ruff check/format passed after clearing four additional toolchain
+  findings. Fresh 500/700 °C `--viz --paranoid` runs reproduced 630/831 and
+  631/831 release with 2.13×/13.55× rise and 275×/32.3× fall. All five
+  regenerated CSV/SVG/JSON products are byte-identical to the tracked
+  artifacts, all nine relative report links resolve, and both rasterized SVGs
+  were visually inspected with readable, unclipped two-panel PASS plots.
 
 ## Result
 
@@ -62,7 +70,9 @@ kinds, rules, and barrier provenance (§4 table).
   falls 32.3× from its early peak — PASS.
 - Verification: both complete runs exited at the truthful no-possible-event
   state under `--paranoid`; `cargo test` passed 42 tests; focused Python
-  suite passed 10 tests; generated SVGs were rasterized and visually checked.
+  suite passed 10 tests; Clippy and Ruff passed; generated SVGs were rasterized
+  and visually checked. No runtime activation applies; dissertation has no
+  installed service for these paths.
 - No quantitative fit is claimed. Every phase-2 limitation and proxy is
   enumerated in the result doc. Executable continuation is captured by
   `E2-muscovite-full-mechanism`; the numerical-range engine defect found

--- a/docs/program/cards/E1-muscovite-deck.md
+++ b/docs/program/cards/E1-muscovite-deck.md
@@ -41,6 +41,11 @@ kinds, rules, and barrier provenance (§4 table).
   rise-then-fall gates, plots, gap ledger, full Petra suite, and focused
   post-processing tests. DEVIATION: phase 1 uses one tracked deck per fixed
   temperature because B5 schedule/schema-v2 support has not landed.
+- 2026-08-20 — hermes-workstation — merged-main re-verification found four
+  default-Ruff E731 violations in the SVG helper. Replaced the local lambdas
+  with typed nested functions without changing output; the full Petra suite,
+  focused post-processing tests, Ruff, and regenerated-result equivalence are
+  the follow-up gate.
 
 ## Result
 
@@ -57,7 +62,7 @@ kinds, rules, and barrier provenance (§4 table).
   falls 32.3× from its early peak — PASS.
 - Verification: both complete runs exited at the truthful no-possible-event
   state under `--paranoid`; `cargo test` passed 42 tests; focused Python
-  suite passed 7 tests; generated SVGs were rasterized and visually checked.
+  suite passed 10 tests; generated SVGs were rasterized and visually checked.
 - No quantitative fit is claimed. Every phase-2 limitation and proxy is
   enumerated in the result doc. Executable continuation is captured by
   `E2-muscovite-full-mechanism`; the numerical-range engine defect found

--- a/petra/crates/petra-core/src/engine.rs
+++ b/petra/crates/petra-core/src/engine.rs
@@ -296,7 +296,7 @@ impl Engine {
 
         self.time += dt;
         self.step_count += 1;
-        if self.step_count % REBUILD_EVERY == 0 {
+        if self.step_count.is_multiple_of(REBUILD_EVERY) {
             self.tree.rebuild();
         }
         Ok(Fired {
@@ -451,7 +451,9 @@ mod tests {
 
         // Every probe must land on a nonzero-rate leaf whose prefix window
         // contains the target, matching a linear scan.
-        let probes = [0.0, 0.4999, 0.5, 1.0, 2.4999, 2.5, 3.7, 5.7499, 5.75, 6.9999];
+        let probes = [
+            0.0, 0.4999, 0.5, 1.0, 2.4999, 2.5, 3.7, 5.7499, 5.75, 6.9999,
+        ];
         for &p in &probes {
             let (idx, residual) = tree.find(p).expect("nonzero leaves exist");
             // linear reference
@@ -465,7 +467,10 @@ mod tests {
                 acc += r;
             }
             assert_eq!(idx, want, "probe {p}");
-            assert!(residual >= 0.0 && residual <= rates[idx] + 1e-12, "probe {p}");
+            assert!(
+                residual >= 0.0 && residual <= rates[idx] + 1e-12,
+                "probe {p}"
+            );
         }
     }
 

--- a/petra/crates/petra-deck/src/compile.rs
+++ b/petra/crates/petra-deck/src/compile.rs
@@ -683,7 +683,7 @@ pub fn compile(deck: &DeckFile) -> Result<CompiledDeck, CompileError> {
     }
 
     let dims = deck.lattice.dims;
-    if dims.iter().any(|&d| d == 0) {
+    if dims.contains(&0) {
         return err("lattice dims must be nonzero");
     }
 
@@ -885,6 +885,7 @@ fn state_in_kind(names: &Names, kind: u16, name: &str, ctx: &str) -> Result<Stat
 
 /// Compile the set/shift/map trio into an EffectOp. `kind` scopes state-name
 /// resolution and is required for `set`/`map`.
+#[allow(clippy::too_many_arguments)] // Mirrors the deck's mutually exclusive op fields.
 fn compile_op(
     names: &Names,
     kind: Option<u16>,

--- a/petra/crates/petra-deck/tests/strain_gates.rs
+++ b/petra/crates/petra-deck/tests/strain_gates.rs
@@ -152,7 +152,7 @@ fn strain_rate_coupling_is_exact() {
     // Both sites are interior with identical 4-neighbor environments; the
     // only rate difference is the strain term: k1/k2 = exp((u1 − u2)/RT)
     // for scale = −1.
-    let s1 = 1 * 9 + 1; // at the core (u = 4)
+    let s1 = 10; // at the core (u = 4)
     let s2 = 5 * 9 + 5; // far away
     let k1 = resolve_rate(lat, &kinds, rxn, s1, 300.0, &mut scratch);
     let k2 = resolve_rate(lat, &kinds, rxn, s2, 300.0, &mut scratch);

--- a/petra/crates/petra-deck/tests/strain_gates.rs
+++ b/petra/crates/petra-deck/tests/strain_gates.rs
@@ -152,7 +152,7 @@ fn strain_rate_coupling_is_exact() {
     // Both sites are interior with identical 4-neighbor environments; the
     // only rate difference is the strain term: k1/k2 = exp((u1 − u2)/RT)
     // for scale = −1.
-    let s1 = 10; // at the core (u = 4)
+    let s1 = 1 * 9 + 1; // at the core (u = 4)
     let s2 = 5 * 9 + 5; // far away
     let k1 = resolve_rate(lat, &kinds, rxn, s1, 300.0, &mut scratch);
     let k2 = resolve_rate(lat, &kinds, rxn, s2, 300.0, &mut scratch);

--- a/petra/scripts/muscovite_release.py
+++ b/petra/scripts/muscovite_release.py
@@ -338,6 +338,18 @@ def _ticks(low: float, high: float, count: int = 5) -> list[float]:
     return [low + index * (high - low) / (count - 1) for index in range(count)]
 
 
+def _span(low: float, high: float) -> float:
+    """Non-zero plot span, so a collapsed range renders as a degenerate plot.
+
+    When every x (or y) value in a panel is identical, ``high - low`` is zero
+    and the ``sx``/``sy`` scale functions would divide by zero. Return a unit
+    span instead so all points map to the same coordinate rather than raising.
+    """
+
+    span = high - low
+    return span if span > 0.0 else 1.0
+
+
 def _svg_panels(results: tuple[RunResult, ...], metric: str) -> str:
     width = 1100
     panel_height = 340
@@ -375,14 +387,21 @@ def _svg_panels(results: tuple[RunResult, ...], metric: str) -> str:
             y_high = math.ceil(max(ys))
             y_precision = 1
 
+        # Guard against a degenerate panel (all values identical) collapsing
+        # the range to zero, which would divide by zero in sx/sy below.
+        if x_high <= x_low:
+            x_high = x_low + 1.0
+        if y_high <= y_low:
+            y_high = y_low + 1.0
+
         def display_y(value: float) -> str:
             return f"{value:.{y_precision}f}"
 
         def sx(value: float) -> float:
-            return x0 + (value - x_low) * plot_width / (x_high - x_low)
+            return x0 + (value - x_low) * plot_width / _span(x_low, x_high)
 
         def sy(value: float) -> float:
-            return y0 + plot_height - (value - y_low) * plot_height / (y_high - y_low)
+            return y0 + plot_height - (value - y_low) * plot_height / _span(y_low, y_high)
 
         parts.extend(
             [

--- a/petra/scripts/muscovite_release.py
+++ b/petra/scripts/muscovite_release.py
@@ -65,22 +65,70 @@ class RunResult:
 # The short-time heat-content expansion handles smaller tau without needing
 # hundreds of roots. Values are fixed mathematical constants, not model data.
 CYLINDER_J0_ZEROS = (
-    2.40482555769577, 5.52007811028631, 8.65372791291101, 11.7915344390143,
-    14.9309177084878, 18.0710639679109, 21.2116366298793, 24.3524715307493,
-    27.4934791320403, 30.634606468432, 33.7758202135736, 36.917098353664,
-    40.0584257646282, 43.1997917131767, 46.3411883716618, 49.4826098973978,
-    52.624051841115, 55.76551075502, 58.9069839260809, 62.0484691902272,
-    65.1899648002069, 68.3314693298568, 71.4729816035937, 74.6145006437018,
-    77.7560256303881, 80.8975558711376, 84.0390907769382, 87.1806298436412,
-    90.3221726372105, 93.4637187819448, 96.6052679509963, 99.7468198586806,
-    102.888374254195, 106.029930916452, 109.171489649805, 112.313050280495,
-    115.454612653667, 118.596176630873, 121.737742087951, 124.879308913233,
-    128.020877006008, 131.162446275214, 134.304016638305, 137.445588020284,
-    140.587160352854, 143.72873357369, 146.870307625797, 150.011882456955,
-    153.153458019228, 156.295034268534, 159.436611164263, 162.578188668947,
-    165.719766747955, 168.861345369236, 172.002924503078, 175.144504121903,
-    178.286084200074, 181.427664713731, 184.569245640639, 187.710826960049,
-    190.852408652582, 193.993990700109, 197.135573085661, 200.277155793332,
+    2.40482555769577,
+    5.52007811028631,
+    8.65372791291101,
+    11.7915344390143,
+    14.9309177084878,
+    18.0710639679109,
+    21.2116366298793,
+    24.3524715307493,
+    27.4934791320403,
+    30.634606468432,
+    33.7758202135736,
+    36.917098353664,
+    40.0584257646282,
+    43.1997917131767,
+    46.3411883716618,
+    49.4826098973978,
+    52.624051841115,
+    55.76551075502,
+    58.9069839260809,
+    62.0484691902272,
+    65.1899648002069,
+    68.3314693298568,
+    71.4729816035937,
+    74.6145006437018,
+    77.7560256303881,
+    80.8975558711376,
+    84.0390907769382,
+    87.1806298436412,
+    90.3221726372105,
+    93.4637187819448,
+    96.6052679509963,
+    99.7468198586806,
+    102.888374254195,
+    106.029930916452,
+    109.171489649805,
+    112.313050280495,
+    115.454612653667,
+    118.596176630873,
+    121.737742087951,
+    124.879308913233,
+    128.020877006008,
+    131.162446275214,
+    134.304016638305,
+    137.445588020284,
+    140.587160352854,
+    143.72873357369,
+    146.870307625797,
+    150.011882456955,
+    153.153458019228,
+    156.295034268534,
+    159.436611164263,
+    162.578188668947,
+    165.719766747955,
+    168.861345369236,
+    172.002924503078,
+    175.144504121903,
+    178.286084200074,
+    181.427664713731,
+    184.569245640639,
+    187.710826960049,
+    190.852408652582,
+    193.993990700109,
+    197.135573085661,
+    200.277155793332,
 )
 
 
@@ -97,8 +145,7 @@ def cylinder_fraction(tau: float) -> float:
     if tau < 1.0e-3:
         return min(1.0, 4.0 * math.sqrt(tau / math.pi) - tau)
     retained = 4.0 * sum(
-        math.exp(-(root * root) * tau) / (root * root)
-        for root in CYLINDER_J0_ZEROS
+        math.exp(-(root * root) * tau) / (root * root) for root in CYLINDER_J0_ZEROS
     )
     return max(0.0, min(1.0, 1.0 - retained))
 
@@ -159,7 +206,9 @@ def _release_events(events: Path) -> tuple[list[float], dict[str, int]]:
             if not isinstance(row, list) or len(row) != 4:
                 raise ValueError(f"{events}:{line_number}: invalid event row")
             _, time_s, reaction_id, _ = row
-            if not isinstance(reaction_id, int) or not 0 <= reaction_id < len(reactions):
+            if not isinstance(reaction_id, int) or not 0 <= reaction_id < len(
+                reactions
+            ):
                 raise ValueError(f"{events}:{line_number}: invalid reaction id")
             time_s = float(time_s)
             if time_s < previous_time:
@@ -315,7 +364,7 @@ def _svg_panels(results: tuple[RunResult, ...], metric: str) -> str:
             x_label, y_label = "sqrt(time / s)", "fraction released"
             x_low, x_high = 0.0, max(xs) * 1.03
             y_low, y_high = 0.0, max(ys) * 1.05
-            display_y = lambda value: f"{value:.2f}"
+            y_precision = 2
         else:
             xs = [point.fraction for point in result.points]
             raw_y = [point.apparent_da2_per_s for point in result.points]
@@ -324,11 +373,17 @@ def _svg_panels(results: tuple[RunResult, ...], metric: str) -> str:
             x_low, x_high = 0.0, max(xs) * 1.03
             y_low = math.floor(min(ys))
             y_high = math.ceil(max(ys))
-            display_y = lambda value: f"{value:.1f}"
-        sx = lambda value: x0 + (value - x_low) * plot_width / (x_high - x_low)
-        sy = lambda value: y0 + plot_height - (value - y_low) * plot_height / (
-            y_high - y_low
-        )
+            y_precision = 1
+
+        def display_y(value: float) -> str:
+            return f"{value:.{y_precision}f}"
+
+        def sx(value: float) -> float:
+            return x0 + (value - x_low) * plot_width / (x_high - x_low)
+
+        def sy(value: float) -> float:
+            return y0 + plot_height - (value - y_low) * plot_height / (y_high - y_low)
+
         parts.extend(
             [
                 f'<rect x="{x0}" y="{y0}" width="{plot_width}" height="{plot_height}" fill="#ffffff" stroke="#4b5563"/>',
@@ -337,18 +392,32 @@ def _svg_panels(results: tuple[RunResult, ...], metric: str) -> str:
         )
         for value in _ticks(x_low, x_high):
             x = sx(value)
-            parts.append(f'<line x1="{x:.2f}" y1="{y0}" x2="{x:.2f}" y2="{y0 + plot_height}" stroke="#e5e7eb"/>')
-            parts.append(f'<text x="{x:.2f}" y="{y0 + plot_height + 22}" text-anchor="middle" font-family="monospace" font-size="12">{value:.2g}</text>')
+            parts.append(
+                f'<line x1="{x:.2f}" y1="{y0}" x2="{x:.2f}" y2="{y0 + plot_height}" stroke="#e5e7eb"/>'
+            )
+            parts.append(
+                f'<text x="{x:.2f}" y="{y0 + plot_height + 22}" text-anchor="middle" font-family="monospace" font-size="12">{value:.2g}</text>'
+            )
         for value in _ticks(y_low, y_high):
             y = sy(value)
-            parts.append(f'<line x1="{x0}" y1="{y:.2f}" x2="{x0 + plot_width}" y2="{y:.2f}" stroke="#e5e7eb"/>')
-            parts.append(f'<text x="{x0 - 12}" y="{y + 4:.2f}" text-anchor="end" font-family="monospace" font-size="12">{display_y(value)}</text>')
+            parts.append(
+                f'<line x1="{x0}" y1="{y:.2f}" x2="{x0 + plot_width}" y2="{y:.2f}" stroke="#e5e7eb"/>'
+            )
+            parts.append(
+                f'<text x="{x0 - 12}" y="{y + 4:.2f}" text-anchor="end" font-family="monospace" font-size="12">{display_y(value)}</text>'
+            )
         coordinates = " ".join(
             f"{sx(x):.2f},{sy(y):.2f}" for x, y in zip(xs, ys, strict=True)
         )
-        parts.append(f'<polyline points="{coordinates}" fill="none" stroke="#b42318" stroke-width="3"/>')
-        parts.append(f'<text x="{x0 + plot_width / 2}" y="{y0 + plot_height + 48}" text-anchor="middle" font-family="sans-serif" font-size="14">{html.escape(x_label)}</text>')
-        parts.append(f'<text x="{x0 + 4}" y="{origin_y + 42}" font-family="sans-serif" font-size="12" fill="#374151">{html.escape(y_label)}</text>')
+        parts.append(
+            f'<polyline points="{coordinates}" fill="none" stroke="#b42318" stroke-width="3"/>'
+        )
+        parts.append(
+            f'<text x="{x0 + plot_width / 2}" y="{y0 + plot_height + 48}" text-anchor="middle" font-family="sans-serif" font-size="14">{html.escape(x_label)}</text>'
+        )
+        parts.append(
+            f'<text x="{x0 + 4}" y="{origin_y + 42}" font-family="sans-serif" font-size="12" fill="#374151">{html.escape(y_label)}</text>'
+        )
         verdict = result.gate
         verdict_text = "gate PASS" if verdict.pass_all else "gate FAIL"
         verdict_fill = "#166534" if verdict.pass_all else "#b42318"

--- a/petra/scripts/tests/test_muscovite_release.py
+++ b/petra/scripts/tests/test_muscovite_release.py
@@ -194,6 +194,34 @@ class SvgPanelTests(unittest.TestCase):
         self.assertIn('fill="#166534"', passing)
         self.assertIn('fill="#b42318"', failing)
 
+    def test_collapsed_range_does_not_divide_by_zero(self) -> None:
+        # All x (and y) values identical -> x_high == x_low and y_high == y_low.
+        # sx/sy must not raise ZeroDivisionError; the panel renders degenerate.
+        points = tuple(
+            muscovite_release.ReleasePoint(
+                fraction=0.02,
+                released=1,
+                time_s=1.0,
+                sqrt_time_sqrt_s=1.0,
+                cylinder_tau=0.01,
+                apparent_da2_per_s=1.0,
+            )
+            for _ in range(3)
+        )
+        gate = muscovite_release.evaluate_gate(points, 100, 6)
+        result = muscovite_release.RunResult(
+            label="flat",
+            temperature_c=500.0,
+            run_dir=".",
+            reaction_counts={},
+            points=points,
+            gate=gate,
+        )
+        for metric in ("release", "da2"):
+            svg = muscovite_release._svg_panels((result,), metric)
+            self.assertIn("<svg", svg)
+            self.assertIn("<polyline", svg)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/petra/scripts/tests/test_muscovite_release.py
+++ b/petra/scripts/tests/test_muscovite_release.py
@@ -29,8 +29,7 @@ class CylinderInversionTests(unittest.TestCase):
     def test_short_time_limit(self) -> None:
         fraction = 0.02
         expected = (
-            2.0 / (3.141592653589793**0.5)
-            - (4.0 / 3.141592653589793 - fraction) ** 0.5
+            2.0 / (3.141592653589793**0.5) - (4.0 / 3.141592653589793 - fraction) ** 0.5
         ) ** 2
         self.assertAlmostEqual(
             muscovite_release.invert_cylinder_fraction(fraction),


### PR DESCRIPTION
## Summary
- follow up merged E1 PR #46 after independent merged-main verification exposed four Ruff E731 violations in the new SVG post-processor
- replace the local plotting lambdas with typed helpers, format the focused Python surface, and clear four current Rust 1.92 Clippy findings without changing simulation behavior
- record the follow-up proof in the E1 card and program status

## Test plan
- `cargo test` — 42 passed
- `cargo clippy --workspace --all-targets -- -D warnings` — passed
- `ruff check scripts/muscovite_release.py scripts/tests/test_muscovite_release.py` — passed
- `ruff format --check scripts/muscovite_release.py scripts/tests/test_muscovite_release.py` — passed
- `python3 -m unittest discover -s scripts/tests -p 'test_*.py' -v` — 10 passed
- fresh nice/OMP-capped `cargo run --release -p petra-cli` executions for both 500 °C and 700 °C decks with `--viz --paranoid` — truthful no-event termination, 630/831 and 631/831 Ar released
- regenerated post-processing gate — PASS at both temperatures (rise 2.13×/13.55×; fall 275×/32.3×)
- `diff -qr` against all five tracked CSV/SVG/JSON products — byte-identical
- all nine relative result-document links resolve; both regenerated SVGs rasterized and visually checked for readable, unclipped two-panel PASS plots

## Breaking changes
None.

## Summary by Sourcery

Close the E1 merged-main quality gate by hardening SVG plotting and clearing current lint findings without changing simulation outputs.

Bug Fixes:
- Prevent SVG post-processing from failing when a plotted metric has a collapsed range.

Enhancements:
- Resolve current Rust Clippy findings and Ruff violations while preserving simulation behavior.
- Update the E1 card and program status with merged-main verification results and artifact equivalence evidence.

Tests:
- Expand post-processing coverage for degenerate SVG plot ranges and confirm the full Rust and focused Python verification suites pass.