### PR TITLE
fix(petra): close E1 Ruff format gate

### DIFF
--- a/docs/program/STATUS.md
+++ b/docs/program/STATUS.md
@@ -4,6 +4,9 @@
 appended by the PR that did it: `date — actor — what + pointer`.
 Deviations get a `DEVIATION:` note; details live in the card.*
 
+- 2026-08-20 — hermes-workstation — E1 Ruff-format closeout: reformatted the
+  cloud review-fix commit's long SVG `sy()` expression so merged-main Ruff
+  0.15.1 check/format gates are clean; no simulation semantics changed.
 - 2026-08-20 — hermes-workstation — E1 merged-main closeout: removed four
   default-Ruff E731 violations from the muscovite SVG post-processor with
   typed local helpers, cleared current Clippy findings, and reverified both

--- a/docs/program/cards/E1-muscovite-deck.md
+++ b/docs/program/cards/E1-muscovite-deck.md
@@ -54,6 +54,9 @@ kinds, rules, and barrier provenance (§4 table).
   regenerated CSV/SVG/JSON products are byte-identical to the tracked
   artifacts, all nine relative report links resolve, and both rasterized SVGs
   were visually inspected with readable, unclipped two-panel PASS plots.
+- 2026-08-20 — hermes-workstation — a fresh merged-main Ruff 0.15.1 format
+  check caught the cloud review-fix commit's long `sy()` expression. Reformatted
+  that expression only; no model, gate, or artifact semantics changed.
 
 ## Result
 

--- a/petra/scripts/muscovite_release.py
+++ b/petra/scripts/muscovite_release.py
@@ -401,7 +401,9 @@ def _svg_panels(results: tuple[RunResult, ...], metric: str) -> str:
             return x0 + (value - x_low) * plot_width / _span(x_low, x_high)
 
         def sy(value: float) -> float:
-            return y0 + plot_height - (value - y_low) * plot_height / _span(y_low, y_high)
+            return (
+                y0 + plot_height - (value - y_low) * plot_height / _span(y_low, y_high)
+            )
 
         parts.extend(
             [


### PR DESCRIPTION
## Summary
- format the long SVG `sy()` expression added by PR #47's cloud review-fix commit so Ruff 0.15.1 format checking passes on merged main
- record the fresh E1 closeout finding in the board card and program status
- preserve simulation behavior and generated artifacts byte-for-byte

## Test plan
- `cargo test` — 42 passed on the identical Rust tree
- `cargo clippy -- -D warnings`
- `python3 -m unittest discover -s petra/scripts/tests -p 'test_*.py' -v` — 11 passed
- `ruff check petra/scripts/muscovite_release.py petra/scripts/tests/test_muscovite_release.py`
- `ruff format --check petra/scripts/muscovite_release.py petra/scripts/tests/test_muscovite_release.py`
- fresh 500 C and 700 C `--viz --paranoid` trajectories — 630/831 and 631/831 released; rise/fall gates PASS
- regenerated 500/700 CSV, two SVGs, and summary JSON byte-identical to tracked artifacts; all 9 relative report links resolve

## Breaking changes
None. Formatting and bookkeeping only. No installed-service activation applies.

## Summary by Sourcery

Close the E1 Ruff formatting gate while preserving simulation semantics and generated outputs.

Enhancements:
- Reformat the long SVG coordinate expression so the merged-main Ruff formatting gate passes without changing simulation behavior or generated artifacts.

Documentation:
- Record the E1 Ruff-format closeout in the program status and Muscovite deck card.