### PR TITLE
fix(petra): restore E1 all-target Clippy gate

### DIFF
--- a/docs/program/STATUS.md
+++ b/docs/program/STATUS.md
@@ -4,6 +4,9 @@
 appended by the PR that did it: `date — actor — what + pointer`.
 Deviations get a `DEVIATION:` note; details live in the card.*
 
+- 2026-08-20 — hermes-workstation — E1 exact-main lint closeout: restored the
+  one-line `strain_gates.rs` identity-op fix that the prior squash merge omitted;
+  targeted strain gates and workspace all-target Clippy are green.
 - 2026-08-20 — hermes-workstation — E1 Ruff-format closeout: reformatted the
   cloud review-fix commit's long SVG `sy()` expression so merged-main Ruff
   0.15.1 check/format gates are clean; no simulation semantics changed.

--- a/docs/program/STATUS.md
+++ b/docs/program/STATUS.md
@@ -6,7 +6,8 @@ Deviations get a `DEVIATION:` note; details live in the card.*
 
 - 2026-08-20 — hermes-workstation — E1 exact-main lint closeout: restored the
   one-line `strain_gates.rs` identity-op fix that the prior squash merge omitted;
-  targeted strain gates and workspace all-target Clippy are green.
+  all Rust/Python/lint gates plus both full trajectories and generated-product
+  equivalence are green.
 - 2026-08-20 — hermes-workstation — E1 Ruff-format closeout: reformatted the
   cloud review-fix commit's long SVG `sy()` expression so merged-main Ruff
   0.15.1 check/format gates are clean; no simulation semantics changed.

--- a/docs/program/cards/E1-muscovite-deck.md
+++ b/docs/program/cards/E1-muscovite-deck.md
@@ -60,7 +60,12 @@ kinds, rules, and barrier provenance (§4 table).
 - 2026-08-20 — hermes-workstation — exact-main closeout after PR #48 found
   that the earlier pushed `strain_gates.rs` identity-op correction was absent
   from the squash-merged tree. Restored the one-line Clippy fix on a fresh
-  follow-up branch; the five strain gates and workspace all-target Clippy pass.
+  follow-up branch; 42 Rust tests, 11 focused Python tests, workspace
+  all-target Clippy, Ruff check/format, and release build pass. Both complete
+  `--viz --paranoid` trajectories again release 630/831 and 631/831 Ar with
+  the 2.13×/13.55× rise and 275.5×/32.3× fall gates passing; all five
+  regenerated products byte-match the tracked artifacts, all nine report
+  links resolve, and both rasterized plots are readable and unclipped.
 
 ## Result
 

--- a/docs/program/cards/E1-muscovite-deck.md
+++ b/docs/program/cards/E1-muscovite-deck.md
@@ -57,6 +57,10 @@ kinds, rules, and barrier provenance (§4 table).
 - 2026-08-20 — hermes-workstation — a fresh merged-main Ruff 0.15.1 format
   check caught the cloud review-fix commit's long `sy()` expression. Reformatted
   that expression only; no model, gate, or artifact semantics changed.
+- 2026-08-20 — hermes-workstation — exact-main closeout after PR #48 found
+  that the earlier pushed `strain_gates.rs` identity-op correction was absent
+  from the squash-merged tree. Restored the one-line Clippy fix on a fresh
+  follow-up branch; the five strain gates and workspace all-target Clippy pass.
 
 ## Result
 

--- a/petra/crates/petra-deck/tests/strain_gates.rs
+++ b/petra/crates/petra-deck/tests/strain_gates.rs
@@ -152,7 +152,7 @@ fn strain_rate_coupling_is_exact() {
     // Both sites are interior with identical 4-neighbor environments; the
     // only rate difference is the strain term: k1/k2 = exp((u1 − u2)/RT)
     // for scale = −1.
-    let s1 = 1 * 9 + 1; // at the core (u = 4)
+    let s1 = 10; // at the core (u = 4)
     let s2 = 5 * 9 + 5; // far away
     let k1 = resolve_rate(lat, &kinds, rxn, s1, 300.0, &mut scratch);
     let k2 = resolve_rate(lat, &kinds, rxn, s2, 300.0, &mut scratch);


### PR DESCRIPTION
## Summary

- restore the one-line `strain_gates.rs` identity-operation cleanup that was present in the prior follow-up branch but absent from the squash-merged tree
- record the exact-main closeout in the E1 card and program status
- preserve simulation semantics; this changes only an equivalent test-site index expression plus bookkeeping

## Test plan

- `cargo test --workspace` — 42 passed
- `cargo clippy --workspace --all-targets -- -D warnings` — passed
- `python3 -m unittest discover -s scripts/tests -p 'test_*.py' -v` — 11 passed
- `ruff check scripts/muscovite_release.py scripts/tests/test_muscovite_release.py` — passed
- `ruff format --check scripts/muscovite_release.py scripts/tests/test_muscovite_release.py` — passed
- `cargo build --release -p petra-cli` — passed
- full 500 °C and 700 °C `--viz --paranoid` trajectories — 630/831 and 631/831 Ar released; rise 2.13×/13.55× and fall 275.5×/32.3×; both gates PASS
- all five regenerated CSV/SVG/JSON products byte-match the tracked artifacts; all nine relative report links resolve; both rasterized plots inspected clean

## Breaking changes

None.

## Summary by Sourcery

Restore the omitted Clippy cleanup and document the completed E1 validation closeout without changing simulation behavior.

Bug Fixes:
- Restore the E1 all-target Clippy gate by reinstating the strain-gate test cleanup omitted during squash merge.

Documentation:
- Record the E1 exact-main lint closeout and validation results in the program status and E1 card.