### PR TITLE
fix(petra): preserve slow events after Fenwick cancellation

### DIFF
--- a/docs/program/STATUS.md
+++ b/docs/program/STATUS.md
@@ -4,6 +4,11 @@
 appended by the PR that did it: `date — actor — what + pointer`.
 Deviations get a `DEVIATION:` note; details live in the card.*
 
+- 2026-08-20 — hermes-cloud-default — QI3 Fenwick cancellation hardening:
+  impossible zero totals now rebuild from authoritative positive leaves; a
+  deterministic `1e12`/`1e-6 s⁻¹` regression, all 43 Petra tests, and an
+  explicit 1000-step Kossel `--paranoid` run are green.
+
 - 2026-08-20 — hermes-workstation — E1 exact-main lint closeout: restored the
   one-line `strain_gates.rs` identity-op fix that the prior squash merge omitted;
   all Rust/Python/lint gates plus both full trajectories and generated-product

--- a/docs/program/cards/QI3-fenwick-total-cancellation.md
+++ b/docs/program/cards/QI3-fenwick-total-cancellation.md
@@ -54,6 +54,6 @@ Verification on Rust 1.97.0:
 - Explicit `petra examples/kossel.toml --steps 1000 --paranoid`: completed 1000
   steps and wrote populations successfully.
 - `git diff --check`: clean.
-- Strict Clippy has no new finding from this change; both `origin/main` and this
+- Strict Clippy has no new findings from this change; both `origin/main` and this
   branch report the same three pre-existing `unnecessary_unwrap` findings in
   `petra-core/src/reaction.rs` under Rust 1.97.0.

--- a/docs/program/cards/QI3-fenwick-total-cancellation.md
+++ b/docs/program/cards/QI3-fenwick-total-cancellation.md
@@ -1,11 +1,11 @@
 # QI3-fenwick-total-cancellation — preserve slow events beside extreme rates
 
-- status: ready
+- status: done
 - track: B (platform quality infrastructure)
 - priority: P1
 - machine: any
 - depends: —
-- claimed-by:
+- claimed-by: hermes-cloud-default
 
 ## Objective
 Harden Petra's incremental Fenwick event total against catastrophic
@@ -33,3 +33,27 @@ boundary before redesigning the summation structure.
 - 2026-08-20 — created from the E1 muscovite phase-1 numerical-range finding;
   the E1 deck uses a scientifically sufficient 1 s⁻¹ surface rate and is not
   blocked on this hardening.
+- 2026-08-20 — hermes-cloud-default reproduced the defect with a deterministic
+  two-site deck: removing a one-shot `1e12 s⁻¹` event left a live `1e-6 s⁻¹`
+  leaf while the incrementally maintained Fenwick total became zero. Added the
+  regression first (observed `Stop::ZeroRate`), then repaired the impossible
+  total by rebuilding from authoritative leaves before terminal classification.
+
+## Result
+Petra now preserves slow events after catastrophic incremental-total
+cancellation without changing ordinary selection or RNG draw order. The repair
+is an O(N) leaf rebuild only at the impossible `total <= 0` boundary when cached
+positive events still exist; a genuinely empty system still returns
+`Stop::NoEvents`, and a still-nonpositive rebuilt total remains the truthful
+`Stop::ZeroRate` fallback.
+
+Verification on Rust 1.97.0:
+- Focused deterministic regression: RED as `Stop::ZeroRate`, then GREEN.
+- `cargo test --workspace`: 43 tests passed, including the kaolinite dynamics
+  tests that call the paranoid differential oracle.
+- Explicit `petra examples/kossel.toml --steps 1000 --paranoid`: completed 1000
+  steps and wrote populations successfully.
+- `git diff --check`: clean.
+- Strict Clippy has no new finding from this change; both `origin/main` and this
+  branch report the same three pre-existing `unnecessary_unwrap` findings in
+  `petra-core/src/reaction.rs` under Rust 1.97.0.

--- a/petra/crates/petra-core/src/engine.rs
+++ b/petra/crates/petra-core/src/engine.rs
@@ -242,12 +242,20 @@ impl Engine {
         self.site_events[s] = events;
     }
 
+    fn terminal_stop(&self) -> Stop {
+        if self.site_events.iter().any(|events| !events.is_empty()) {
+            Stop::ZeroRate
+        } else {
+            Stop::NoEvents
+        }
+    }
+
     /// One KMC step: select, apply, propagate, advance time.
     pub fn step(&mut self) -> Result<Fired, Stop> {
         let mut total = self.tree.total();
         if total <= 0.0 {
-            let any = self.site_events.iter().any(|e| !e.is_empty());
-            if any {
+            let stop = self.terminal_stop();
+            if stop == Stop::ZeroRate {
                 // Removing an extreme rate can cancel much smaller surviving
                 // rates out of an incrementally maintained internal node.
                 // The leaves remain authoritative, so repair this impossible
@@ -256,15 +264,14 @@ impl Engine {
                 total = self.tree.total();
             }
             if total <= 0.0 {
-                return Err(if any { Stop::ZeroRate } else { Stop::NoEvents });
+                return Err(stop);
             }
         }
 
         // Site, then event within site. A `None` here means the positive
         // `total` was pure accumulated drift over zero leaves — no events.
         let Some((site, mut residual)) = self.tree.find(self.rng.gen::<f64>() * total) else {
-            let any = self.site_events.iter().any(|e| !e.is_empty());
-            return Err(if any { Stop::ZeroRate } else { Stop::NoEvents });
+            return Err(self.terminal_stop());
         };
         let events = &self.site_events[site];
         debug_assert!(!events.is_empty(), "tree selected an event-less site");

--- a/petra/crates/petra-core/src/engine.rs
+++ b/petra/crates/petra-core/src/engine.rs
@@ -244,10 +244,20 @@ impl Engine {
 
     /// One KMC step: select, apply, propagate, advance time.
     pub fn step(&mut self) -> Result<Fired, Stop> {
-        let total = self.tree.total();
+        let mut total = self.tree.total();
         if total <= 0.0 {
             let any = self.site_events.iter().any(|e| !e.is_empty());
-            return Err(if any { Stop::ZeroRate } else { Stop::NoEvents });
+            if any {
+                // Removing an extreme rate can cancel much smaller surviving
+                // rates out of an incrementally maintained internal node.
+                // The leaves remain authoritative, so repair this impossible
+                // total before deciding that the simulation is terminal.
+                self.tree.rebuild();
+                total = self.tree.total();
+            }
+            if total <= 0.0 {
+                return Err(if any { Stop::ZeroRate } else { Stop::NoEvents });
+            }
         }
 
         // Site, then event within site. A `None` here means the positive

--- a/petra/crates/petra-deck/tests/analytic_gates.rs
+++ b/petra/crates/petra-deck/tests/analytic_gates.rs
@@ -231,3 +231,98 @@ fn mean_waiting_time_tracks_total_rate() {
         "mean dt·R_total: got {mean:.4}, expected 1.0"
     );
 }
+
+const EXTREME_RATE_CANCELLATION: &str = r#"
+[deck]
+name = "extreme-rate-cancellation"
+comment = "a fast one-shot event must not erase a surviving slow event"
+
+[cell]
+a = 5.0
+b = 5.0
+c = 5.0
+alpha = 90.0
+beta = 90.0
+gamma = 90.0
+
+[[cell.sites]]
+kind = "Fast"
+frac = [0.0, 0.0, 0.0]
+
+[[cell.sites]]
+kind = "Slow"
+frac = [0.5, 0.5, 0.5]
+
+[[species]]
+name = "X"
+
+[[kinds]]
+name = "Fast"
+initial = "armed"
+
+[[kinds.states]]
+name = "armed"
+occupant = "X"
+
+[[kinds.states]]
+name = "done"
+occupant = "X"
+
+[[kinds]]
+name = "Slow"
+initial = "armed"
+
+[[kinds.states]]
+name = "armed"
+occupant = "X"
+
+[[kinds.states]]
+name = "done"
+occupant = "X"
+
+[lattice]
+dims = [1, 1, 1]
+boundary = ["open", "open", "open"]
+
+[thermo]
+temperature = 300.0
+
+[[reactions]]
+name = "fast_once"
+center = { kind = "Fast", state = ["armed"] }
+rate = { constant = 1.0e12 }
+
+[[reactions.effects]]
+target = "center"
+set = "done"
+
+[[reactions]]
+name = "slow_once"
+center = { kind = "Slow", state = ["armed"] }
+rate = { constant = 1.0e-6 }
+
+[[reactions.effects]]
+target = "center"
+set = "done"
+
+[simulation]
+steps = 3
+seed = 1998
+"#;
+
+#[test]
+fn extreme_fast_event_cannot_erase_surviving_slow_event() {
+    let parsed: petra_deck::DeckFile =
+        toml::from_str(EXTREME_RATE_CANCELLATION).expect("valid deck");
+    let deck = petra_deck::compile(&parsed).expect("compiles");
+    let mut engine = deck.build_engine(Some(1998)).expect("engine builds");
+
+    let fast = engine.step().expect("fast event fires");
+    assert_eq!(fast.site, 0);
+
+    let slow = engine
+        .step()
+        .expect("surviving slow event must not be lost to Fenwick cancellation");
+    assert_eq!(slow.site, 1);
+    assert_eq!(engine.step(), Err(petra_core::Stop::NoEvents));
+}

--- a/petra/crates/petra-deck/tests/analytic_gates.rs
+++ b/petra/crates/petra-deck/tests/analytic_gates.rs
@@ -315,7 +315,7 @@ fn extreme_fast_event_cannot_erase_surviving_slow_event() {
     let parsed: petra_deck::DeckFile =
         toml::from_str(EXTREME_RATE_CANCELLATION).expect("valid deck");
     let deck = petra_deck::compile(&parsed).expect("compiles");
-    let mut engine = deck.build_engine(Some(1998)).expect("engine builds");
+    let mut engine = deck.build_engine(None).expect("engine builds");
 
     let fast = engine.step().expect("fast event fires");
     assert_eq!(fast.site, 0);


### PR DESCRIPTION
## Summary
- reproduce catastrophic Fenwick cancellation with a deterministic two-site `1e12` / `1e-6 s^-1` deck
- rebuild the tree from authoritative leaves only when the cached total is impossible (`<= 0`) while positive cached events remain
- preserve ordinary-run performance and deterministic RNG order; retain truthful `NoEvents` / `ZeroRate` terminal reasons
- close board card QI3 with its Progress/Result and a program STATUS line

## Root cause
`RateTree::set` updates internal Fenwick nodes by floating-point delta. A `1e-6` leaf can be rounded out when sharing a node with `1e12`; removing the fast leaf then subtracts `1e12` from that rounded node and leaves a false zero total even though the slow leaf is still positive.

## Test plan
- [x] TDD regression observed `Stop::ZeroRate` before the repair and passes after it
- [x] `cargo test --workspace` — 43 tests passed
- [x] explicit 1000-step Kossel run with `--paranoid` completed successfully
- [x] `git diff --check`

## Baseline note
On Rust 1.97.0, strict Clippy reports the same three pre-existing `unnecessary_unwrap` findings in `petra-core/src/reaction.rs` on both `origin/main` and this branch. This PR introduces no new Clippy finding and does not expand scope into that baseline cleanup.

## Worker/watcher separation
Per mission-control POLICY.md v7, this worker opens the PR and stops. The cloud PR watcher owns review fixes, CI handling, and merge gates.

## Summary by Sourcery

Harden Petra’s event scheduling against floating-point Fenwick cancellation so surviving slow events remain selectable after extreme-rate events are removed.

Bug Fixes:
- Prevent catastrophic Fenwick total cancellation from discarding surviving slow-rate events.
- Preserve accurate `NoEvents` and `ZeroRate` terminal outcomes after total recovery.

Enhancements:
- Keep ordinary event selection and deterministic RNG behavior unchanged while repairing impossible cached totals.

Documentation:
- Mark the QI3 Fenwick cancellation card complete and record the fix and verification results in program status documentation.

Tests:
- Add a deterministic regression covering a `1e12` fast event alongside a `1e-6` slow event and verify both fire in order.