### PR TITLE
feat(quarry): enforce campaign compute etiquette

### DIFF
--- a/docs/program/PLAN.md
+++ b/docs/program/PLAN.md
@@ -27,7 +27,7 @@ on main). Priority P0 > P1 > P2 within READY.
 |---|---|---|---|---|---|
 | [B1-schema-rfc](cards/B1-schema-rfc.md) | B | P0 | any | done | — |
 | [B2-engine-refactor](cards/B2-engine-refactor.md) | B | P0 | any | ready | B1 ✅ |
-| [QI1-driver-enforced-etiquette](cards/QI1-driver-enforced-etiquette.md) | A | P2 | any | ready | — |
+| [QI1-driver-enforced-etiquette](cards/QI1-driver-enforced-etiquette.md) | A | P2 | any | done | — |
 | [QI2-gpu-lease](cards/QI2-gpu-lease.md) | A | P1 | any | ready | — |
 | [QI3-fenwick-total-cancellation](cards/QI3-fenwick-total-cancellation.md) | B | P1 | any | ready | — |
 | [E1-muscovite-deck](cards/E1-muscovite-deck.md) | E | P1 | any | done | — (phase 1 isothermal) |
@@ -43,7 +43,8 @@ on main). Priority P0 > P1 > P2 within READY.
 | [D3-ice-mantle-deck](cards/D3-ice-mantle-deck.md) | D | P2 | any | blocked: B3 + D2a | B3, D2a |
 | [A5p0-aging-observables](cards/A5p0-aging-observables.md) | A | P1 | any | blocked: B4 | B4 |
 
-**Done** (acceptance verified on main): B1-schema-rfc (PR #25),
+**Done** (acceptance verified on main): QI1-driver-enforced-etiquette,
+B1-schema-rfc (PR #25),
 D2a-astro-rate-reproduction (PR #31 — verdict: GO gas-phase /
 NO-GO surface-LH), A7-kinetics-database (PR #27 — 36 minerals, 74
 mechanisms, validator green). **Active**: A3-barrier-ladder

--- a/docs/program/STATUS.md
+++ b/docs/program/STATUS.md
@@ -4,6 +4,10 @@
 appended by the PR that did it: `date — actor — what + pointer`.
 Deviations get a `DEVIATION:` note; details live in the card.*
 
+- 2026-08-20 — hermes-laptop — QI1 campaign-driver etiquette done: all QM
+  entry points now cap inherited numerical-library threads before heavy imports,
+  apply best-effort niceness, and self-tee durable logs; 162 tests, Ruff, direct
+  CLI smoke checks, and an unset-environment Phase-2 dry run are green.
 - 2026-08-20 — hermes-cloud-default — QI3 Fenwick cancellation hardening:
   impossible zero totals now rebuild from authoritative positive leaves; a
   deterministic `1e12`/`1e-6 s⁻¹` regression, all 43 Petra tests, and an

--- a/docs/program/cards/QI1-driver-enforced-etiquette.md
+++ b/docs/program/cards/QI1-driver-enforced-etiquette.md
@@ -60,4 +60,5 @@ because the box was lightly loaded). Move enforcement into the code:
 
 ## Progress
 
+- 2026-08-20 22:51 UTC — Implementation and verification checkpoint: added `quarry.etiquette`, wired all four campaign entry points before heavy imports, and added CLI/logging gates. `uv run --frozen pytest -q` passed (162 tests), `ruff check .` passed, and an unset-environment Phase-2 dry run reported all three managed thread variables at 16.
 - 2026-08-20 — card created (fable) after the live 22-thread probe.

--- a/docs/program/cards/QI1-driver-enforced-etiquette.md
+++ b/docs/program/cards/QI1-driver-enforced-etiquette.md
@@ -1,6 +1,6 @@
 # QI1-driver-enforced-etiquette — campaign drivers enforce their own compute caps
 
-- status: ready
+- status: done
 - track: A (quarry infrastructure)
 - priority: P2
 - machine: any (code + tests; no campaigns needed)
@@ -60,5 +60,26 @@ because the box was lightly loaded). Move enforcement into the code:
 
 ## Progress
 
+- 2026-08-20 22:55 UTC — Done. Full QM test/lint gates and direct CLI smoke checks are green; implementation, card, board, and program status are ready in the single card PR.
 - 2026-08-20 22:51 UTC — Implementation and verification checkpoint: added `quarry.etiquette`, wired all four campaign entry points before heavy imports, and added CLI/logging gates. `uv run --frozen pytest -q` passed (162 tests), `ruff check .` passed, and an unset-environment Phase-2 dry run reported all three managed thread variables at 16.
 - 2026-08-20 — card created (fable) after the live 22-thread probe.
+
+## Result
+
+Implemented `qm/quarry/etiquette.py` with a default 16-thread cap across
+`OMP_NUM_THREADS`, `MKL_NUM_THREADS`, and `OPENBLAS_NUM_THREADS`, best-effort
+niceness, non-root negative-nice rejection, and automatic stdout/stderr teeing
+to an explicit `--log` path or a timestamped file under `qm/runs/`. All four
+campaign entry points bootstrap it before NumPy/PySCF/quarry heavy imports and
+accept explicit `--threads`, `--nice`, and `--log` overrides. The entry-point
+inventory test makes this convention fail closed for newly added scripts.
+
+Verification:
+
+- `uv run --frozen pytest -q` — 162 passed.
+- `uv run --frozen ruff check .` — clean.
+- Direct `--help --nice 0 --log ...` smoke checks passed for all four entry points.
+- With all three managed environment variables deliberately unset,
+  `phase2_ladder.py --family oss --dry-run --threads 16 --nice 0` printed
+  `OMP_NUM_THREADS=16 MKL_NUM_THREADS=16 OPENBLAS_NUM_THREADS=16` before heavy
+  imports and completed the no-DFT geometry/metadata run.

--- a/qm/quarry/etiquette.py
+++ b/qm/quarry/etiquette.py
@@ -1,0 +1,154 @@
+"""Runtime enforcement for polite quarry campaign resource use."""
+
+from __future__ import annotations
+
+import argparse
+import atexit
+import os
+import sys
+import time
+import warnings
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TextIO
+
+THREAD_ENV_VARS = (
+    "OMP_NUM_THREADS",
+    "MKL_NUM_THREADS",
+    "OPENBLAS_NUM_THREADS",
+)
+
+
+def enforce(threads: int = 16, niceness: int = 10) -> None:
+    """Cap numerical-library threads and best-effort lower process priority.
+
+    Unset thread variables are initialized to ``threads``. Inherited values
+    above the cap (or malformed values) are clamped; valid lower values are
+    preserved so enforcement never inflates an existing limit.
+    """
+    if threads < 1:
+        raise ValueError("threads must be at least 1")
+    if niceness < 0:
+        geteuid = getattr(os, "geteuid", None)
+        if geteuid is None or geteuid() != 0:
+            raise ValueError("negative niceness requires root")
+
+    for name in THREAD_ENV_VARS:
+        inherited = os.environ.get(name)
+        try:
+            within_cap = inherited is not None and 1 <= int(inherited) <= threads
+        except ValueError:
+            within_cap = False
+        if not within_cap:
+            os.environ[name] = str(threads)
+
+    try:
+        nice = os.nice
+    except AttributeError:
+        warnings.warn(
+            "os.nice() unavailable; continuing without niceness", stacklevel=2
+        )
+        return
+    try:
+        nice(niceness)
+    except OSError as exc:
+        warnings.warn(
+            f"os.nice({niceness}) failed; continuing: {exc}",
+            stacklevel=2,
+        )
+
+
+class _Tee:
+    """Minimal text stream that duplicates writes to a durable log."""
+
+    def __init__(self, console: TextIO, log: TextIO) -> None:
+        self.console = console
+        self.log = log
+
+    def write(self, text: str) -> int:
+        written = self.console.write(text)
+        self.log.write(text)
+        return written
+
+    def flush(self) -> None:
+        self.console.flush()
+        self.log.flush()
+
+    def __getattr__(self, name: str):
+        return getattr(self.console, name)
+
+
+@dataclass
+class EtiquetteSession:
+    """Applied campaign limits and the active tee, restorable for tests."""
+
+    threads: int
+    niceness: int
+    log_path: Path
+    _stdout: TextIO
+    _stderr: TextIO
+    _log: TextIO
+    _closed: bool = False
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        if isinstance(sys.stdout, _Tee) and sys.stdout.log is self._log:
+            sys.stdout = self._stdout
+        if isinstance(sys.stderr, _Tee) and sys.stderr.log is self._log:
+            sys.stderr = self._stderr
+        self._log.flush()
+        self._log.close()
+        self._closed = True
+
+
+def bootstrap_cli(
+    script_name: str,
+    *,
+    default_run_root: str | Path,
+    argv: list[str] | None = None,
+) -> EtiquetteSession:
+    """Pre-parse etiquette flags, enforce them, and tee campaign output.
+
+    Entry-point scripts call this before importing NumPy, PySCF, or quarry
+    modules that may import them. Unknown arguments are deliberately retained
+    for each script's full parser.
+    """
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--threads", type=int, default=16)
+    parser.add_argument("--nice", type=int, default=10)
+    parser.add_argument("--log")
+    args, _ = parser.parse_known_args(argv)
+
+    if args.threads < 1:
+        parser.error("--threads must be at least 1")
+    geteuid = getattr(os, "geteuid", None)
+    if args.nice < 0 and (geteuid is None or geteuid() != 0):
+        parser.error("negative --nice requires root")
+
+    if args.log:
+        log_path = Path(args.log).expanduser()
+    else:
+        stamp = time.strftime("%Y%m%dT%H%M%S")
+        log_path = Path(default_run_root) / f"{script_name}-{stamp}-{os.getpid()}.log"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+
+    original_stdout, original_stderr = sys.stdout, sys.stderr
+    print(f"campaign log: {log_path}", file=original_stdout, flush=True)
+    log = log_path.open("a", encoding="utf-8", buffering=1)
+    sys.stdout = _Tee(original_stdout, log)
+    sys.stderr = _Tee(original_stderr, log)
+    session = EtiquetteSession(
+        threads=args.threads,
+        niceness=args.nice,
+        log_path=log_path,
+        _stdout=original_stdout,
+        _stderr=original_stderr,
+        _log=log,
+    )
+    atexit.register(session.close)
+    enforce(threads=args.threads, niceness=args.nice)
+    print(f"campaign log: {log_path}", flush=True)
+    limits = " ".join(f"{name}={os.environ[name]}" for name in THREAD_ENV_VARS)
+    print(f"compute etiquette: {limits}; nice increment={args.nice}", flush=True)
+    return session

--- a/qm/scripts/astro_rate_reproduction.py
+++ b/qm/scripts/astro_rate_reproduction.py
@@ -22,9 +22,20 @@ import json
 import os
 import platform
 import subprocess
+import sys
 import time
 from dataclasses import dataclass, replace
 from pathlib import Path
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+if __name__ == "__main__":
+    from quarry.etiquette import bootstrap_cli
+
+    bootstrap_cli(
+        "astro_rate_reproduction",
+        default_run_root=Path(__file__).resolve().parent.parent / "runs",
+    )
 
 import numpy as np
 
@@ -458,6 +469,11 @@ def provenance(reaction: Reaction, structures: list[Cluster]) -> dict:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--threads", type=int, default=16, help="numerical thread cap")
+    parser.add_argument(
+        "--nice", type=int, default=10, help="process niceness increment"
+    )
+    parser.add_argument("--log", help="tee output to this path (default: qm/runs)")
     parser.add_argument(
         "--reaction", action="append", help="reaction key (repeatable; default all)"
     )
@@ -471,9 +487,6 @@ def main() -> int:
         "--force", action="store_true", help="recompute completed results"
     )
     args = parser.parse_args()
-    os.environ.setdefault("OMP_NUM_THREADS", "16")
-    if int(os.environ["OMP_NUM_THREADS"]) > 16:
-        raise SystemExit("OMP_NUM_THREADS must be <=16")
     all_reactions = reactions(gpu=args.gpu, basis=args.basis)
     selected = args.reaction or list(all_reactions)
     unknown = sorted(set(selected) - set(all_reactions))

--- a/qm/scripts/phase0_smoke.py
+++ b/qm/scripts/phase0_smoke.py
@@ -22,8 +22,17 @@ import platform
 import sys
 import time
 from dataclasses import dataclass
+from pathlib import Path
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+if __name__ == "__main__":
+    from quarry.etiquette import bootstrap_cli
+
+    bootstrap_cli(
+        "phase0_smoke",
+        default_run_root=Path(__file__).resolve().parent.parent / "runs",
+    )
 
 from quarry.clusters import silicic_acid_hydrate, water  # noqa: E402
 from quarry.pipeline import DftSettings, _make_scf, build_mol  # noqa: E402
@@ -128,6 +137,9 @@ def time_engine(cluster, settings: DftSettings, *, hessian: bool) -> Timing:
 
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--threads", type=int, default=16, help="numerical thread cap")
+    ap.add_argument("--nice", type=int, default=10, help="process niceness increment")
+    ap.add_argument("--log", help="tee output to this path (default: qm/runs)")
     ap.add_argument(
         "--quick",
         action="store_true",

--- a/qm/scripts/phase1_xiao_lasaga.py
+++ b/qm/scripts/phase1_xiao_lasaga.py
@@ -37,6 +37,14 @@ from pathlib import Path
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
+if __name__ == "__main__":
+    from quarry.etiquette import bootstrap_cli
+
+    bootstrap_cli(
+        "phase1_xiao_lasaga",
+        default_run_root=Path(__file__).resolve().parent.parent / "runs",
+    )
+
 import numpy as np  # noqa: E402
 
 from quarry.clusters import (  # noqa: E402
@@ -842,6 +850,8 @@ def main() -> int:
         default=16,
         help="OMP thread cap for CPU stages (default 16 — leave the box usable)",
     )
+    ap.add_argument("--nice", type=int, default=10, help="process niceness increment")
+    ap.add_argument("--log", help="tee output to this path (default: qm/runs)")
     ap.add_argument(
         "--approach",
         choices=["flank", "backside"],
@@ -852,7 +862,6 @@ def main() -> int:
     ap.add_argument("--temperature", type=float, default=298.15)
     args = ap.parse_args()
 
-    os.environ.setdefault("OMP_NUM_THREADS", str(args.threads))
     settings = DftSettings(
         xc=args.xc, basis=args.basis, density_fit=True, use_gpu=args.gpu
     )

--- a/qm/scripts/phase2_ladder.py
+++ b/qm/scripts/phase2_ladder.py
@@ -31,6 +31,14 @@ from pathlib import Path
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
+if __name__ == "__main__":
+    from quarry.etiquette import bootstrap_cli
+
+    bootstrap_cli(
+        "phase2_ladder",
+        default_run_root=Path(__file__).resolve().parent.parent / "runs",
+    )
+
 import numpy as np  # noqa: E402
 
 from quarry.clusters import Cluster, hydronium, water  # noqa: E402
@@ -310,6 +318,8 @@ def main() -> int:
     ap.add_argument("--basis", default="def2-svp")
     ap.add_argument("--gpu", action="store_true")
     ap.add_argument("--threads", type=int, default=16)
+    ap.add_argument("--nice", type=int, default=10, help="process niceness increment")
+    ap.add_argument("--log", help="tee output to this path (default: qm/runs)")
     ap.add_argument("--temperature", type=float, default=298.15)
     ap.add_argument("--dry-run", action="store_true")
     ap.add_argument(
@@ -319,7 +329,6 @@ def main() -> int:
     )
     args = ap.parse_args()
 
-    os.environ.setdefault("OMP_NUM_THREADS", str(args.threads))
     if args.gpu:
         preload_cutensor()
     qm_root = Path(__file__).resolve().parent.parent

--- a/qm/tests/test_etiquette.py
+++ b/qm/tests/test_etiquette.py
@@ -1,3 +1,4 @@
+import ast
 import os
 import re
 import sys
@@ -80,7 +81,31 @@ def test_all_campaign_entrypoints_bootstrap_before_heavy_imports():
     scripts = Path(__file__).resolve().parent.parent / "scripts"
     for path in sorted(scripts.glob("*.py")):
         source = path.read_text()
+        tree = ast.parse(source)
         bootstrap_at = source.find("bootstrap_cli(")
+        bootstrap_calls = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "bootstrap_cli"
+        ]
+        main_guards = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.If)
+            and isinstance(node.test, ast.Compare)
+            and isinstance(node.test.left, ast.Name)
+            and node.test.left.id == "__name__"
+            and len(node.test.ops) == 1
+            and isinstance(node.test.ops[0], ast.Eq)
+            and len(node.test.comparators) == 1
+            and isinstance(node.test.comparators[0], ast.Constant)
+            and node.test.comparators[0].value == "__main__"
+        ]
+        guarded_nodes = {
+            nested for guard in main_guards for nested in ast.walk(guard)
+        }
         heavy_imports = [
             match.start()
             for match in re.finditer(
@@ -90,6 +115,10 @@ def test_all_campaign_entrypoints_bootstrap_before_heavy_imports():
             )
         ]
         assert bootstrap_at >= 0, f"{path.name} does not bootstrap etiquette"
+        assert bootstrap_calls, f"{path.name} does not call bootstrap_cli"
+        assert all(call in guarded_nodes for call in bootstrap_calls), (
+            f"{path.name} calls bootstrap_cli outside its __main__ guard"
+        )
         assert heavy_imports, f"{path.name} has no recognized heavy import"
         assert bootstrap_at < min(heavy_imports), (
             f"{path.name} bootstraps after a heavy import"

--- a/qm/tests/test_etiquette.py
+++ b/qm/tests/test_etiquette.py
@@ -1,0 +1,99 @@
+import os
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+from quarry.etiquette import THREAD_ENV_VARS, bootstrap_cli, enforce
+
+
+def test_enforce_sets_unset_clamps_high_and_preserves_low(monkeypatch):
+    monkeypatch.delenv("OMP_NUM_THREADS", raising=False)
+    monkeypatch.setenv("MKL_NUM_THREADS", "64")
+    monkeypatch.setenv("OPENBLAS_NUM_THREADS", "4")
+    nice_calls = []
+    monkeypatch.setattr(os, "nice", nice_calls.append)
+
+    enforce(threads=16, niceness=10)
+
+    assert {name: os.environ[name] for name in THREAD_ENV_VARS} == {
+        "OMP_NUM_THREADS": "16",
+        "MKL_NUM_THREADS": "16",
+        "OPENBLAS_NUM_THREADS": "4",
+    }
+    assert nice_calls == [10]
+
+
+def test_negative_niceness_is_rejected_for_non_root(monkeypatch):
+    monkeypatch.setattr(os, "geteuid", lambda: 1000)
+    monkeypatch.setattr(
+        os, "nice", lambda value: pytest.fail("os.nice must not be called")
+    )
+
+    with pytest.raises(ValueError, match="negative niceness requires root"):
+        enforce(niceness=-1)
+
+
+def test_niceness_failure_warns_and_continues(monkeypatch):
+    monkeypatch.setattr(
+        os, "nice", lambda value: (_ for _ in ()).throw(OSError("not permitted"))
+    )
+
+    with pytest.warns(UserWarning, match="continuing"):
+        enforce(niceness=10)
+
+
+def test_bootstrap_cli_applies_overrides_and_self_tees(monkeypatch, tmp_path):
+    for name in THREAD_ENV_VARS:
+        monkeypatch.setenv(name, "64")
+    nice_calls = []
+    monkeypatch.setattr(os, "nice", nice_calls.append)
+    original_stdout, original_stderr = sys.stdout, sys.stderr
+
+    session = bootstrap_cli(
+        "driver",
+        default_run_root=tmp_path,
+        argv=["--threads", "32", "--nice", "5"],
+    )
+    try:
+        print("durable campaign output")
+        sys.stdout.flush()
+    finally:
+        session.close()
+
+    assert session.threads == 32
+    assert session.niceness == 5
+    assert session.log_path.parent == tmp_path
+    log_text = session.log_path.read_text()
+    assert "durable campaign output" in log_text
+    assert "OMP_NUM_THREADS=32" in log_text
+    assert "MKL_NUM_THREADS=32" in log_text
+    assert "OPENBLAS_NUM_THREADS=32" in log_text
+    assert {os.environ[name] for name in THREAD_ENV_VARS} == {"32"}
+    assert nice_calls == [5]
+    assert sys.stdout is original_stdout
+    assert sys.stderr is original_stderr
+
+
+def test_all_campaign_entrypoints_bootstrap_before_heavy_imports():
+    scripts = Path(__file__).resolve().parent.parent / "scripts"
+    for path in sorted(scripts.glob("*.py")):
+        source = path.read_text()
+        bootstrap_at = source.find("bootstrap_cli(")
+        heavy_imports = [
+            match.start()
+            for match in re.finditer(
+                r"^(?:import numpy|from (?!quarry\.etiquette\b)quarry\.)",
+                source,
+                re.MULTILINE,
+            )
+        ]
+        assert bootstrap_at >= 0, f"{path.name} does not bootstrap etiquette"
+        assert heavy_imports, f"{path.name} has no recognized heavy import"
+        assert bootstrap_at < min(heavy_imports), (
+            f"{path.name} bootstraps after a heavy import"
+        )
+        assert '"--threads"' in source
+        assert '"--nice"' in source
+        assert '"--log"' in source

--- a/qm/tests/test_etiquette.py
+++ b/qm/tests/test_etiquette.py
@@ -92,7 +92,7 @@ def test_all_campaign_entrypoints_bootstrap_before_heavy_imports():
         ]
         main_guards = [
             node
-            for node in ast.walk(tree)
+            for node in tree.body
             if isinstance(node, ast.If)
             and isinstance(node.test, ast.Compare)
             and isinstance(node.test.left, ast.Name)
@@ -104,7 +104,10 @@ def test_all_campaign_entrypoints_bootstrap_before_heavy_imports():
             and node.test.comparators[0].value == "__main__"
         ]
         guarded_nodes = {
-            nested for guard in main_guards for nested in ast.walk(guard)
+            nested
+            for guard in main_guards
+            for statement in guard.body
+            for nested in ast.walk(statement)
         }
         heavy_imports = [
             match.start()


### PR DESCRIPTION
## Summary
- add `quarry.etiquette` for hard numerical thread caps and best-effort niceness before heavy imports
- tee every campaign entry point to an explicit or timestamped durable log
- expose `--threads`, `--nice`, and `--log` consistently and fail new entry points that omit the bootstrap
- close the QI1 board card with board/status bookkeeping in the same PR

## Verification
- `uv run --frozen pytest -q` — 162 passed
- `uv run --frozen ruff check .` — clean
- direct `--help --nice 0 --log ...` smoke checks on all four campaign entry points
- deliberately-unset Phase-2 dry run reported `OMP_NUM_THREADS=16 MKL_NUM_THREADS=16 OPENBLAS_NUM_THREADS=16` and completed without DFT

## Summary by Sourcery

Enforce resource etiquette and durable logging consistently across all quarry campaign drivers.

New Features:
- Add shared campaign compute etiquette with configurable thread caps, best-effort process niceness, and durable output logging.
- Expose consistent `--threads`, `--nice`, and `--log` options across all campaign entry points, with automatic timestamped logs by default.

Bug Fixes:
- Ensure numerical-library thread limits are applied before heavy scientific imports and newly added campaign scripts fail validation if they omit the etiquette bootstrap.

Enhancements:
- Preserve lower inherited thread limits while clamping excessive or invalid values, and reject unsupported negative niceness for non-root users.

Documentation:
- Mark the QI1 driver-enforced etiquette work as complete in the program plan, status, and work card.

Tests:
- Add coverage for resource-limit enforcement, niceness handling, durable tee logging, CLI overrides, and entry-point bootstrap ordering.