### PR TITLE
docs: PROTOCOL finishing section — align with POLICY v7 merge doctrine

### DIFF
--- a/docs/program/PROTOCOL.md
+++ b/docs/program/PROTOCOL.md
@@ -98,8 +98,9 @@ repairs, branch updates against main, and the squash-merge. Do NOT
 enable auto-merge, reply to or resolve review threads, poll checks, or
 merge locally; a worker racing the watcher corrupts both. To hold a PR
 for human/Fable review instead, add the `human-merge` label. A PR
-still open after ~48h means the watcher has stalled: flag it (the
-daily supervisor also watches for this). Background on the underlying
+still open after ~48h means the watcher has stalled: add the
+`needs-human` label to that PR; the daily `omnibus-supervisor` (07:50)
+also watches for this. Background on the underlying
 gates (four required checks, strict up-to-date, required conversation
 resolution): `.claude/learnings/` and the memory of PRs #12–#21.
 

--- a/docs/program/PROTOCOL.md
+++ b/docs/program/PROTOCOL.md
@@ -90,14 +90,18 @@ Your PR contains, atomically:
 3. One line appended to [`STATUS.md`](STATUS.md) (newest first).
 4. Any new follow-up cards (status: ready or blocked) your work exposed.
 
-Open the PR (`gh pr create`), enable auto-merge
-(`gh pr merge --auto --squash`), then **deal with review**: this repo
-requires all four checks green, the branch up to date with main
-(merge main in if a concurrent PR lands first), and **every Sourcery
-review thread resolved** (fix legitimate points, then resolve via the
-GraphQL `resolveReviewThread` mutation — the PR will sit silently
-BLOCKED forever if you skip this). Known failure modes and diagnostics:
-`.claude/learnings/` and the memory of PRs #12–#21.
+Open the PR (`gh pr create`) — **then STOP** (amended 2026-08-20 to
+match fleet POLICY §1 v7, which supersedes the old wording here): this
+repo is webhook-wired, and the cloud Hermes PR watcher owns the rest
+of the lifecycle — review fixes (including Sourcery threads), CI
+repairs, branch updates against main, and the squash-merge. Do NOT
+enable auto-merge, reply to or resolve review threads, poll checks, or
+merge locally; a worker racing the watcher corrupts both. To hold a PR
+for human/Fable review instead, add the `human-merge` label. A PR
+still open after ~48h means the watcher has stalled: flag it (the
+daily supervisor also watches for this). Background on the underlying
+gates (four required checks, strict up-to-date, required conversation
+resolution): `.claude/learnings/` and the memory of PRs #12–#21.
 
 ## Machine classes
 

--- a/docs/program/STATUS.md
+++ b/docs/program/STATUS.md
@@ -101,4 +101,7 @@ Deviations get a `DEVIATION:` note; details live in the card.*
   POLICY v7 (open PR and STOP; watcher owns lifecycle; human-merge
   label) — the stale auto-merge/Sourcery wording was flagged by the
   cloud Hermes worker during its enrollment (it correctly refused to
-  follow it). Companion factory fixes landed in mission-control.
+  follow it). Companion fixes landed in `vsletten/mission-control`
+  commit `a2edf91`: `factory/hermes/cron/queue-drain.md` now points to
+  POLICY v7, and service activation moved to
+  `factory/services/activate.sh` for cloud-safe installation.

--- a/docs/program/STATUS.md
+++ b/docs/program/STATUS.md
@@ -93,3 +93,8 @@ Deviations get a `DEVIATION:` note; details live in the card.*
   after reviewing overnight A3-pilot/ollama cohabitation (22 ollama
   loads, all-GPU, zero errors — but pilot peaked 21.7 GB; luck, not
   design) and TASK-168's per-tick hand-rolled preflights.
+- 2026-08-20 — fable — PROTOCOL.md merge-doctrine paragraph aligned to
+  POLICY v7 (open PR and STOP; watcher owns lifecycle; human-merge
+  label) — the stale auto-merge/Sourcery wording was flagged by the
+  cloud Hermes worker during its enrollment (it correctly refused to
+  follow it). Companion factory fixes landed in mission-control.


### PR DESCRIPTION
## Summary
- Replaces the stale auto-merge + self-resolve-Sourcery instructions in the finishing-a-card section with the POLICY v7 contract: open the PR and STOP; the cloud watcher owns review fixes, CI repairs, branch updates, and the merge; `human-merge` label holds a PR for human review; ~48h open = stalled watcher.
- Flagged by the cloud Hermes worker during its queue-worker enrollment (it refused to follow the stale wording and reported the conflict — the system working as designed).

## Test plan
Docs-only.

## Breaking changes
None — this codifies what workers were already required to do by POLICY §1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align PR completion guidance with the POLICY v7 cloud-watcher merge doctrine.

Enhancements:
- Align the protocol’s PR-finishing instructions with POLICY v7 by making workers stop after opening a PR and assigning all subsequent lifecycle work to the cloud watcher, with explicit human-review and stalled-watcher handling.

Documentation:
- Update the program status log to record the POLICY v7 documentation alignment and related operational context.