### PR TITLE
fix(qm): fail GPU runs when cuTENSOR core is unavailable

### DIFF
--- a/qm/scripts/phase2_ladder.py
+++ b/qm/scripts/phase2_ladder.py
@@ -100,16 +100,25 @@ def preload_cutensor() -> None:
     contraction engine, which materializes temporaries that OOM a 24 GB
     card at ~60 atoms/def2-svp (seen live, twice). Preloading by
     absolute path makes cupy's dlopen find them regardless of
-    LD_LIBRARY_PATH. Harmless no-op when the wheel is absent (CPU runs).
+    LD_LIBRARY_PATH. The core library is mandatory for GPU runs; the
+    multi-GPU companion is optional.
     """
     import contextlib
     import ctypes
     import sysconfig
 
     libdir = Path(sysconfig.get_paths()["purelib"]) / "cutensor" / "lib"
-    for name in ("libcutensor.so.2", "libcutensorMg.so.2"):
-        with contextlib.suppress(OSError):
-            ctypes.CDLL(str(libdir / name), mode=ctypes.RTLD_GLOBAL)
+    core = libdir / "libcutensor.so.2"
+    try:
+        ctypes.CDLL(str(core), mode=ctypes.RTLD_GLOBAL)
+    except OSError as exc:
+        raise RuntimeError(
+            f"failed to load required cuTENSOR core library {core}: {exc}; "
+            "install cutensor-cu12 in the active environment before using --gpu"
+        ) from exc
+
+    with contextlib.suppress(OSError):
+        ctypes.CDLL(str(libdir / "libcutensorMg.so.2"), mode=ctypes.RTLD_GLOBAL)
 
 
 def trim_gpu_pool() -> None:

--- a/qm/tests/test_phase2_driver.py
+++ b/qm/tests/test_phase2_driver.py
@@ -1,7 +1,10 @@
 """Fast orchestration gates for the Phase-2 ladder driver (no DFT)."""
 
+import ctypes
 import json
 import sys
+import sysconfig
+from pathlib import Path
 from types import SimpleNamespace
 
 import numpy as np
@@ -12,6 +15,25 @@ from quarry.pipeline import DftSettings
 from scripts import phase2_ladder as phase2
 
 CHEAP = DftSettings(xc="hf", basis="sto-3g")
+
+
+def test_preload_cutensor_fails_loudly_when_core_library_cannot_load(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setattr(sysconfig, "get_paths", lambda: {"purelib": str(tmp_path)})
+
+    attempted = []
+
+    def fail_load(path, *, mode):
+        attempted.append((Path(path).name, mode))
+        raise OSError("shared object not found")
+
+    monkeypatch.setattr(ctypes, "CDLL", fail_load)
+
+    with pytest.raises(RuntimeError, match="required cuTENSOR core library"):
+        phase2.preload_cutensor()
+
+    assert attempted[0] == ("libcutensor.so.2", ctypes.RTLD_GLOBAL)
 
 
 def geometry(name: str, m_ow: float, m_obr: float = 1.6) -> Cluster:


### PR DESCRIPTION
## Summary

Follow-up to #55 for a blocking review finding discovered as that PR merged:

- require `libcutensor.so.2` to preload successfully for `--gpu` runs
- raise an actionable error instead of silently permitting CuPy's memory-heavy fallback
- keep the multi-GPU `libcutensorMg.so.2` companion optional
- add a regression test for a missing/unloadable core library

## Test plan

- `PYTHONPATH="$PWD" pytest -q` — 168 passed
- `ruff check scripts/phase2_ladder.py tests/test_phase2_driver.py` — clean

## Breaking changes

GPU mode now fails early when the required cuTENSOR core library is absent or unloadable. CPU mode is unchanged because preloading only runs under `--gpu`.

## Summary by Sourcery

Require the cuTENSOR core library for GPU runs and report actionable setup errors instead of allowing an inefficient fallback.

Bug Fixes:
- Make GPU runs fail early with an actionable error when the required cuTENSOR core library is missing or cannot be loaded.

Enhancements:
- Keep the optional multi-GPU cuTENSOR companion library best-effort while requiring the core library for GPU execution.

Tests:
- Add regression coverage for loud failure when the cuTENSOR core library cannot be loaded.