### PR TITLE
docs: make A8 archive intake reproducible

### DIFF
--- a/docs/program/cards/A8-thesis-archive-intake.md
+++ b/docs/program/cards/A8-thesis-archive-intake.md
@@ -59,6 +59,12 @@ repo:
    energy. `energy_treatment` must state `electronic` or
    `electronic+ZPE`, and a row must not mix treatments. The Markdown
    ledger explains triplet assignments and every non-`ok` parse status.
+   Encode imaginary frequencies as semicolon-delimited numeric values
+   in ascending order, without unit suffixes (the column unit is cm⁻¹).
+   An empty field means no imaginary mode was found; `parse_status` is
+   one of `ok`, `unmatched`, `truncated`, `ambiguous`, or `parse_error`
+   and distinguishes a clean empty result from incomplete parsing.
+   Encode `normal_termination` as `true` or `false`.
    This is the 1999-vs-2026 comparison base for A3/A7 — same author,
    same reactions, 27 years of method development apart. Flag the
    oxalate/ligand systems distinctly: they are a candidate future track
@@ -85,14 +91,20 @@ repo:
     LC_ALL=C sort > /tmp/thesis-archive.after
   diff -u /tmp/thesis-archive.before /tmp/thesis-archive.after
   ```
+  The `SRC` value is the normative source on this workstation; the
+  `/tmp` output names are examples but must remain outside the archive.
+  Run both manifests on that workstation with GNU `find`, preserve the
+  raw `%T@` precision (no rounding), and compare them byte-for-byte;
+  cross-platform manifest equality is not an acceptance requirement.
   Store the manifest SHA-256 values and clean-diff result in
   `CATALOG.md`. Do not store snapshots under `$SRC`.
 - Repo big-output policy applies: nothing bulky/binary into git
   (no .chk, no .ps, no full 88-run trees). Curate hard.
 - Make parsing reproducible: commit the parser, record its invocation
-  and `python3 --version` in `CATALOG.md`, process each Gaussian Link1
-  section independently, select only normally terminated final jobs,
-  and report truncated/ambiguous logs instead of guessing assignments.
+  and the output of `python3 --version` and `find --version` in
+  `CATALOG.md`, process each Gaussian Link1 section independently,
+  select only normally terminated final jobs, and report
+  truncated/ambiguous logs instead of guessing assignments.
 - Record the successful thesis build command and versions of the TeX
   engine and `latexmk` in `CATALOG.md`. Prefer `latexmk -pdf` with the
   archive's existing engine assumptions; document any compatibility

--- a/docs/program/cards/A8-thesis-archive-intake.md
+++ b/docs/program/cards/A8-thesis-archive-intake.md
@@ -43,13 +43,25 @@ repo:
    no .ps) under `legacy/thesis-archive/`, chosen to span temperature/
    chemistry settings. These become future parity/behavior targets for
    kmc-rs and petra (follow-up card, not this one).
-3. **Barrier ledger**: parse every dft/results/*/ Gaussian log:
+3. **Barrier ledger**: parse every `dft/results/*/` Gaussian log:
    system, method/basis, final energy, frequencies if present, and the
    derived barriers where reactant/TS/product triplets exist. Emit
-   `legacy/thesis-archive/DFT-LEDGER.md` (+ CSV). This is the
-   1999-vs-2026 comparison base for A3/A7 — same author, same
-   reactions, 27 years of method development apart. Flag the oxalate/
-   ligand systems distinctly: they are a candidate future track
+   `legacy/thesis-archive/DFT-LEDGER.md` plus a companion CSV. Use one
+   CSV row per reaction candidate (including unmatched calculations,
+   with unavailable fields left empty) and this fixed schema:
+   `system_id`, `reaction_id`, `ligand_class`, `ref_log`, `ts_log`,
+   `product_log`, `method`, `basis`, `energy_treatment`,
+   `e_ref_hartree`, `e_ts_hartree`, `e_product_hartree`,
+   `barrier_forward_kj_mol`, `barrier_reverse_kj_mol`,
+   `reaction_energy_kj_mol`, `imaginary_frequencies_cm_1`,
+   `normal_termination`, `parse_status`, `notes`. Source energies are
+   hartree and derived energies are kJ mol⁻¹; never emit a unitless
+   energy. `energy_treatment` must state `electronic` or
+   `electronic+ZPE`, and a row must not mix treatments. The Markdown
+   ledger explains triplet assignments and every non-`ok` parse status.
+   This is the 1999-vs-2026 comparison base for A3/A7 — same author,
+   same reactions, 27 years of method development apart. Flag the
+   oxalate/ligand systems distinctly: they are a candidate future track
    (ligand-promoted dissolution, ERW-relevant).
 4. **Thesis text**: verify the LaTeX builds (or convert cleanly);
    place a built PDF (or the .tex tree if small) under
@@ -62,14 +74,39 @@ repo:
 ## Constraints
 - The NAS archive directory is READ-ONLY: never modify, move, or
   delete anything under it. Copy out only.
+- Before copying, write a sorted source metadata manifest outside the
+  archive; repeat it after all work and require a clean diff:
+  ```sh
+  SRC=/home/vsletten/Documents/personal/science/thesis
+  LC_ALL=C find "$SRC" -printf '%P\t%y\t%s\t%T@\n' |
+    LC_ALL=C sort > /tmp/thesis-archive.before
+  # Perform read-only discovery and copy-out work here.
+  LC_ALL=C find "$SRC" -printf '%P\t%y\t%s\t%T@\n' |
+    LC_ALL=C sort > /tmp/thesis-archive.after
+  diff -u /tmp/thesis-archive.before /tmp/thesis-archive.after
+  ```
+  Store the manifest SHA-256 values and clean-diff result in
+  `CATALOG.md`. Do not store snapshots under `$SRC`.
 - Repo big-output policy applies: nothing bulky/binary into git
   (no .chk, no .ps, no full 88-run trees). Curate hard.
-- Text encodings may be 1999-era (latin-1); convert deliberately.
+- Make parsing reproducible: commit the parser, record its invocation
+  and `python3 --version` in `CATALOG.md`, process each Gaussian Link1
+  section independently, select only normally terminated final jobs,
+  and report truncated/ambiguous logs instead of guessing assignments.
+- Record the successful thesis build command and versions of the TeX
+  engine and `latexmk` in `CATALOG.md`. Prefer `latexmk -pdf` with the
+  archive's existing engine assumptions; document any compatibility
+  flags or unavailable legacy packages.
+- Text encodings may be 1999-era. Detect and record the source encoding,
+  preserve the original file hash, and convert only copied artifacts to
+  UTF-8 (for known Latin-1, `iconv -f ISO-8859-1 -t UTF-8`). Never
+  rewrite files in place or silently replace undecodable bytes.
 
 ## Acceptance
-- CATALOG.md + DFT-LEDGER.md (+ CSV) merged; curated artifacts in
-  legacy/thesis-archive/ per above; archive source untouched
-  (verifiable: no mtime changes under the source dir).
+- CATALOG.md + DFT-LEDGER.md (+ schema-compliant CSV) merged; curated
+  artifacts in legacy/thesis-archive/ per above; archive source
+  untouched (verifiable by identical pre/post metadata manifests and
+  their recorded SHA-256 values).
 - Follow-up cards filed.
 
 ## Progress


### PR DESCRIPTION
## Summary

- define a stable, unit-explicit DFT ledger CSV schema for A3/A7
- make the read-only NAS constraint operational with pre/post metadata manifests
- document reproducible Gaussian parsing, TeX build, and legacy-encoding handling

## Context

Follow-up to #57, which merged while the submitted Sourcery review was being addressed. This carries the actionable high-level feedback without recreating the deleted PR branch.

## Verification

- `git diff --check`
- exercised the documented metadata-manifest procedure on a temporary fixture; pre/post SHA-256 values matched

## Summary by Sourcery

Make A8 thesis archive intake reproducible, auditable, and safe while standardizing its DFT outputs.

Enhancements:
- Define a stable, unit-explicit DFT ledger CSV schema with reproducible parsing and explicit handling of incomplete or ambiguous Gaussian results.
- Operationalize the read-only archive constraint with pre/post metadata manifests and recorded integrity verification.
- Document reproducible thesis builds, tool-version capture, and safe legacy-encoding conversion for copied artifacts.

Documentation:
- Expand A8 archive-intake guidance with reproducible Gaussian parsing, TeX build, metadata verification, and legacy-encoding procedures.