### PR TITLE
docs: reconcile Omnibus board after B2

### DIFF
--- a/docs/program/PLAN.md
+++ b/docs/program/PLAN.md
@@ -10,9 +10,9 @@ updated through the same PRs that do the work.*
 |---|---|---|
 | M0 — scoping + in-flight landed | ✅ done 2026-08-18 | Omnibus + 3 scoping docs merged; Phase-1 si-neutral barrier landed (ΔG‡ 27.0 kcal/mol vs X&L ~29) |
 | M1 — B1 schema RFC reviewed | ✅ done 2026-08-19 | RFC-001 merged (PR #25); B2 unblocked |
-| M2 — B2 refactor, parity green | in progress | B2 READY as of B1 merge |
-| M3 — B3 conformance decks green | blocked (B2) | Conway / Ising / SIR with analytic gates |
-| M4 — B4 ensembles + observables | blocked (B2) | design against A5-Phase-0 needs |
+| M2 — B2 refactor, parity green | ✅ done 2026-08-20 | B2 merged in PR #33; schema v2 + bitwise-parity gates green |
+| M3 — B3 conformance decks green | ready | B2 done; Conway / Ising / SIR with analytic gates |
+| M4 — B4 ensembles + observables | ready | B2 done; design against A5-Phase-0 needs |
 | M5 — first science on new platform | blocked (M3/M4) | A5 aging study ∥ C2 corrosion deck ∥ D2 rates campaign |
 | M6 — first external deliverables | blocked (M5) | tool paper, corrosion statistics, KIDA submissions, field-lab mechanism paper |
 
@@ -26,10 +26,10 @@ on main). Priority P0 > P1 > P2 within READY.
 | Card | Track | Priority | Machine | Status | Depends on |
 |---|---|---|---|---|---|
 | [B1-schema-rfc](cards/B1-schema-rfc.md) | B | P0 | any | done | — |
-| [B2-engine-refactor](cards/B2-engine-refactor.md) | B | P0 | any | ready | B1 ✅ |
+| [B2-engine-refactor](cards/B2-engine-refactor.md) | B | P0 | any | done | B1 ✅ |
 | [QI1-driver-enforced-etiquette](cards/QI1-driver-enforced-etiquette.md) | A | P2 | any | done | — |
 | [QI2-gpu-lease](cards/QI2-gpu-lease.md) | A | P1 | any | ready | — |
-| [QI3-fenwick-total-cancellation](cards/QI3-fenwick-total-cancellation.md) | B | P1 | any | ready | — |
+| [QI3-fenwick-total-cancellation](cards/QI3-fenwick-total-cancellation.md) | B | P1 | any | done | — |
 | [E1-muscovite-deck](cards/E1-muscovite-deck.md) | E | P1 | any | done | — (phase 1 isothermal) |
 | [E2-muscovite-full-mechanism](cards/E2-muscovite-full-mechanism.md) | E | P1 | any | blocked: B5 | B5 |
 | [A8-thesis-archive-intake](cards/A8-thesis-archive-intake.md) | A | P1 | workstation | ready | — |
@@ -37,19 +37,21 @@ on main). Priority P0 > P1 > P2 within READY.
 | [A3-barrier-ladder](cards/A3-barrier-ladder.md) | A | P1 | workstation | ready | — |
 | [A7-kinetics-database](cards/A7-kinetics-database.md) | A | P2 | any | done | — |
 | [A2-production-energetics](cards/A2-production-energetics.md) | A | P1 | workstation | blocked: ORCA install (Victor) + A1b | A1b |
-| [B3-conformance-decks](cards/B3-conformance-decks.md) | B | P1 | any | blocked: B2 | B2 |
-| [B4-ensembles-observables](cards/B4-ensembles-observables.md) | B | P1 | any | blocked: B2 | B2 |
-| [B5-execution-schedule](cards/B5-execution-schedule.md) | B | P1 | any | blocked: B2 | B2 |
+| [B3-conformance-decks](cards/B3-conformance-decks.md) | B | P1 | any | ready | B2 ✅ |
+| [B4-ensembles-observables](cards/B4-ensembles-observables.md) | B | P1 | any | ready | B2 ✅ |
+| [B5-execution-schedule](cards/B5-execution-schedule.md) | B | P1 | any | ready | B2 ✅ |
 | [C2-corrosion-deck](cards/C2-corrosion-deck.md) | C | P2 | any | blocked: B3 | B3 |
 | [D3-ice-mantle-deck](cards/D3-ice-mantle-deck.md) | D | P2 | any | blocked: B3 + D2a | B3, D2a |
 | [A5p0-aging-observables](cards/A5p0-aging-observables.md) | A | P1 | any | blocked: B4 | B4 |
 
 **Done** (acceptance verified on main): QI1-driver-enforced-etiquette,
-B1-schema-rfc (PR #25),
+QI3-fenwick-total-cancellation (PR #52), B1-schema-rfc (PR #25),
+B2-engine-refactor (PR #33),
 D2a-astro-rate-reproduction (PR #31 — verdict: GO gas-phase /
 NO-GO surface-LH), A7-kinetics-database (PR #27 — 36 minerals, 74
-mechanisms, validator green). **Active**: A3-barrier-ladder
-(claim branch live).
+mechanisms, validator green). **Active claim**: A1b-acid-mechanisms.
+A3-barrier-ladder remains `in-progress` in its card after platform PR
+#37; that merged PR auto-deleted its remote claim branch.
 
 **Tracked elsewhere**: TASK-164 (scan-smoothness repair + al-neutral
 barrier) predates this board and lives in the mission-control queue —

--- a/docs/program/STATUS.md
+++ b/docs/program/STATUS.md
@@ -2,8 +2,10 @@
 
 *Newest first. One line per merged unit of work (or notable event),
 appended by the PR that did it: `date — actor — what + pointer`.
-Deviations get a `DEVIATION:` note; details live in the card.*
+*Deviations get a `DEVIATION:` note; details live in the card.*
 
+- 2026-08-21 — omnibus supervisor — reconciled merged-main board drift:
+  B2 and QI3 are done; B3, B4, and B5 are now ready after B2 PR #33.
 - 2026-08-20 — hermes x2 + fable — B2 DONE: petra engine behind the
   UpdateStrategy trait, schema v2 complete, bitwise parity green on
   three gates (incl. shipped-kossel full-lifetime). Two-worker relay +

--- a/docs/program/cards/B2-engine-refactor.md
+++ b/docs/program/cards/B2-engine-refactor.md
@@ -1,6 +1,6 @@
 # B2-engine-refactor — petra core behind the UpdateStrategy trait
 
-- status: in-progress
+- status: done
 - track: B (platform)
 - priority: P0
 - machine: any
@@ -21,6 +21,9 @@ strategies in this card (that's B3) — this card is pure refactor.
 
 ## Progress
 
+- 2026-08-21 — omnibus supervisor — reconciled merged-main bookkeeping:
+  PR #33 merged the verified implementation on 2026-08-20; marked B2
+  done and unblocked B3, B4, and B5.
 - 2026-08-20 — hermes worker 1 (sol) — claimed; goldens captured BEFORE
   refactor; ExactCtmc behind the UpdateStrategy trait; v2 shim;
   splitmix64 vectors; 20k byte-identical parity; then adversarial

--- a/docs/program/cards/B3-conformance-decks.md
+++ b/docs/program/cards/B3-conformance-decks.md
@@ -1,6 +1,6 @@
 # B3-conformance-decks — Conway, Ising, SIR with analytic gates
 
-- status: blocked (B2)
+- status: ready
 - track: B (platform)
 - priority: P1
 - machine: any
@@ -20,4 +20,5 @@ threshold vs mean-field. This is the "petra is general now" milestone.
   test, CTMC parity gates still green.
 
 ## Progress
+- 2026-08-21 — omnibus supervisor — unblocked after B2 merged in PR #33.
 - 2026-08-18 — card created (fable).

--- a/docs/program/cards/B4-ensembles-observables.md
+++ b/docs/program/cards/B4-ensembles-observables.md
@@ -1,6 +1,6 @@
 # B4-ensembles-observables — replicas + declarative observables
 
-- status: blocked (B2)
+- status: ready
 - track: B (platform)
 - priority: P1
 - machine: any
@@ -23,4 +23,5 @@ tracking will attach.
   (spectrum broadens as pits nucleate — qualitative gate + golden file).
 
 ## Progress
+- 2026-08-21 — omnibus supervisor — unblocked after B2 merged in PR #33.
 - 2026-08-18 — card created (fable).

--- a/docs/program/cards/B5-execution-schedule.md
+++ b/docs/program/cards/B5-execution-schedule.md
@@ -1,6 +1,6 @@
 # B5-execution-schedule — piecewise-isothermal T(t) schedules
 
-- status: blocked (B2)
+- status: ready
 - track: B (platform)
 - priority: P1
 - machine: any
@@ -31,5 +31,6 @@ unchanged within segments) plus implementation plus tests.
   (compat gate).
 
 ## Progress
+- 2026-08-21 — omnibus supervisor — unblocked after B2 merged in PR #33.
 - 2026-08-19 — card created (fable), motivated by the Ar-muscovite
   scoping doc.


### PR DESCRIPTION
## Summary

- mark B2 and QI3 done on the Omnibus board after their merged implementation PRs
- promote B3, B4, and B5 to ready now that B2 is complete
- refresh milestone and active-claim bookkeeping without changing science or code

## Verification

- `git diff --check`
- board/card status assertions for B2, QI3, B3, B4, and B5
- docs-only changed-file audit

## Exception recorded

A3 remains `in-progress` in its card after platform PR #37, but that merge auto-deleted its remote claim branch; PLAN now states that explicitly instead of claiming the branch is live.

## Summary by Sourcery

Reconcile program documentation with the current merged-main state and accurately record active work claims.

Enhancements:
- Reconcile the Omnibus program board with merged work by marking B2 and QI3 complete and unblocking B3, B4, and B5.
- Clarify active-claim bookkeeping for A3 after its merged platform work removed the remote claim branch.

Documentation:
- Update program milestones, card statuses, completion records, and status history to reflect the latest merged work.