### PR TITLE
feat(petra): add B3 conformance strategies

### DIFF
--- a/docs/program/PLAN.md
+++ b/docs/program/PLAN.md
@@ -11,9 +11,9 @@ updated through the same PRs that do the work.*
 | M0 — scoping + in-flight landed | ✅ done 2026-08-18 | Omnibus + 3 scoping docs merged; Phase-1 si-neutral barrier landed (ΔG‡ 27.0 kcal/mol vs X&L ~29) |
 | M1 — B1 schema RFC reviewed | ✅ done 2026-08-19 | RFC-001 merged (PR #25); B2 unblocked |
 | M2 — B2 refactor, parity green | ✅ done 2026-08-20 | B2 merged in PR #33; schema v2 + bitwise-parity gates green |
-| M3 — B3 conformance decks green | ready | B2 done; Conway / Ising / SIR with analytic gates |
+| M3 — B3 conformance decks green | ✅ done 2026-08-21 | Conway / Ising / SIR analytic gates green; all four update strategies executable |
 | M4 — B4 ensembles + observables | ready | B2 done; design against A5-Phase-0 needs |
-| M5 — first science on new platform | blocked (M3/M4) | A5 aging study ∥ C2 corrosion deck ∥ D2 rates campaign |
+| M5 — first science on new platform | blocked (M4) | M3 done; A5 aging study ∥ C2 corrosion deck ∥ D2 rates campaign |
 | M6 — first external deliverables | blocked (M5) | tool paper, corrosion statistics, KIDA submissions, field-lab mechanism paper |
 
 ## Cards
@@ -37,14 +37,15 @@ on main). Priority P0 > P1 > P2 within READY.
 | [A3-barrier-ladder](cards/A3-barrier-ladder.md) | A | P1 | workstation | ready | — |
 | [A7-kinetics-database](cards/A7-kinetics-database.md) | A | P2 | any | done | — |
 | [A2-production-energetics](cards/A2-production-energetics.md) | A | P1 | workstation | blocked: ORCA install (Victor) + A1b | A1b |
-| [B3-conformance-decks](cards/B3-conformance-decks.md) | B | P1 | any | ready | B2 ✅ |
+| [B3-conformance-decks](cards/B3-conformance-decks.md) | B | P1 | any | done | B2 ✅ |
 | [B4-ensembles-observables](cards/B4-ensembles-observables.md) | B | P1 | any | ready | B2 ✅ |
 | [B5-execution-schedule](cards/B5-execution-schedule.md) | B | P1 | any | ready | B2 ✅ |
-| [C2-corrosion-deck](cards/C2-corrosion-deck.md) | C | P2 | any | blocked: B3 | B3 |
-| [D3-ice-mantle-deck](cards/D3-ice-mantle-deck.md) | D | P2 | any | blocked: B3 + D2a | B3, D2a |
+| [C2-corrosion-deck](cards/C2-corrosion-deck.md) | C | P2 | any | ready | B3 ✅ |
+| [D3-ice-mantle-deck](cards/D3-ice-mantle-deck.md) | D | P2 | any | ready | B3 ✅, D2a ✅ |
 | [A5p0-aging-observables](cards/A5p0-aging-observables.md) | A | P1 | any | blocked: B4 | B4 |
 
-**Done** (acceptance verified on main): QI1-driver-enforced-etiquette,
+**Done** (acceptance verified on main): B3-conformance-decks,
+QI1-driver-enforced-etiquette,
 QI3-fenwick-total-cancellation (PR #52), B1-schema-rfc (PR #25),
 B2-engine-refactor (PR #33),
 D2a-astro-rate-reproduction (PR #31 — verdict: GO gas-phase /

--- a/docs/program/STATUS.md
+++ b/docs/program/STATUS.md
@@ -4,6 +4,10 @@
 appended by the PR that did it: `date — actor — what + pointer`.
 *Deviations get a `DEVIATION:` note; details live in the card.*
 
+- 2026-08-21 — hermes-laptop — B3 DONE: Petra now runs synchronous CA,
+  asynchronous Metropolis, and discrete-time PCA on schema-v2 grids; Conway,
+  Ising (`Tc=2.273230` vs `2.269185`), and SIR (`R0*=1.017094`) analytic gates
+  are green with CTMC bitwise parity preserved.
 - 2026-08-21 — omnibus supervisor — reconciled merged-main board drift:
   B2 and QI3 are done; B3, B4, and B5 are now ready after B2 PR #33.
 - 2026-08-20 — hermes x2 + fable — B2 DONE: petra engine behind the

--- a/docs/program/cards/B3-conformance-decks.md
+++ b/docs/program/cards/B3-conformance-decks.md
@@ -1,6 +1,6 @@
 # B3-conformance-decks — Conway, Ising, SIR with analytic gates
 
-- status: active
+- status: done
 - track: B (platform)
 - priority: P1
 - machine: any
@@ -20,6 +20,32 @@ threshold vs mean-field. This is the "petra is general now" milestone.
   test, CTMC parity gates still green.
 
 ## Progress
+- 2026-08-21 — hermes-laptop — completed B3. Independent pre-commit review first found batch-trajectory, simultaneous-write, tiny-periodic-grid, ensemble-dispatch, and SIR-evidence defects; each was corrected and the second independent review passed with no blocking findings.
 - 2026-08-21 — hermes-laptop — atomically claimed `agents/B3-conformance-decks` from current `origin/main`; began grid compiler and three-strategy conformance implementation under RFC-001 with strict seeded-determinism and CTMC parity gates.
 - 2026-08-21 — omnibus supervisor — unblocked after B2 merged in PR #33.
 - 2026-08-18 — card created (fable).
+
+## Result
+
+Petra now compiles square/hex/cubic schema-v2 grids into deterministic simple
+CSR graphs and executes deck-selected `SynchronousCA`, `AsyncMetropolis`, and
+`DiscreteTimePCA` strategies alongside bitwise-frozen `ExactCtmc`. Batch
+strategies read one pre-step state and commit atomically; conflicting writes
+fail before mutation. Strategy RNG order has pinned trajectory fingerprints,
+and tiny periodic grids are loop/duplicate-free.
+
+The three shipped decks under `petra/examples/conformance/` are permanent CI
+gates. Conway proves glider period 4 with displacement (1,1), blinker period 2,
+and block still-life. The Ising Binder crossing is `2.273230` versus Onsager
+`2.269185` (absolute error `0.004045`, tolerance `0.25`). SIR's interpolated
+growth threshold is `R0=1.017094` (tolerance `0.15` around 1); its finite-lattice
+macroscopic-outbreak probabilities are `0.000000` at `R0=0.5` and `0.476562`
+at `R0=2.0` across the deck-declared 128 hash-seeded replicas.
+
+Verification is green: `cargo test -j 16 --workspace` (including all 12 B3
+conformance tests and all three 20k/full-lifetime CTMC parity gates),
+`cargo clippy --workspace --all-targets -- -D warnings`,
+`cargo fmt --all -- --check`, `cargo build -j 16 --workspace`, and
+`git diff --check`. CLI execution honors the deck's strategy, replica count,
+and seed policy. CTMC trajectory output remains supported; discrete batch
+trajectory requests fail closed instead of emitting ambiguous replay rows.

--- a/docs/program/cards/B3-conformance-decks.md
+++ b/docs/program/cards/B3-conformance-decks.md
@@ -1,11 +1,11 @@
 # B3-conformance-decks — Conway, Ising, SIR with analytic gates
 
-- status: ready
+- status: active
 - track: B (platform)
 - priority: P1
 - machine: any
 - depends: B2
-- claimed-by:
+- claimed-by: hermes-laptop
 
 ## Objective
 Implement SynchronousCA, AsyncMetropolis, and DiscreteTimePCA
@@ -20,5 +20,6 @@ threshold vs mean-field. This is the "petra is general now" milestone.
   test, CTMC parity gates still green.
 
 ## Progress
+- 2026-08-21 — hermes-laptop — atomically claimed `agents/B3-conformance-decks` from current `origin/main`; began grid compiler and three-strategy conformance implementation under RFC-001 with strict seeded-determinism and CTMC parity gates.
 - 2026-08-21 — omnibus supervisor — unblocked after B2 merged in PR #33.
 - 2026-08-18 — card created (fable).

--- a/petra/crates/petra-cli/src/main.rs
+++ b/petra/crates/petra-cli/src/main.rs
@@ -24,7 +24,7 @@ struct Args {
     seed: Option<u64>,
     out: String,
     paranoid: bool,
-    ensemble: u64,
+    ensemble: Option<u64>,
     xyz: bool,
     /// Write trajectory artifacts (snapshot.pgif.json + events.jsonl) for
     /// graph-viz playback.
@@ -38,7 +38,7 @@ fn parse_args() -> Result<Args, String> {
     let mut seed = None;
     let mut out = ".".to_string();
     let mut paranoid = false;
-    let mut ensemble = 1u64;
+    let mut ensemble = None;
     let mut xyz = false;
     let mut viz = false;
     while let Some(a) = args.next() {
@@ -46,14 +46,15 @@ fn parse_args() -> Result<Args, String> {
             "--xyz" => xyz = true,
             "--viz" => viz = true,
             "--ensemble" => {
-                ensemble = args
+                let value = args
                     .next()
                     .ok_or("--ensemble needs a value")?
                     .parse()
                     .map_err(|e| format!("--ensemble: {e}"))?;
-                if ensemble == 0 {
+                if value == 0 {
                     return Err("--ensemble must be at least 1".into());
                 }
+                ensemble = Some(value);
             }
             "--steps" => {
                 steps = Some(
@@ -104,8 +105,15 @@ fn main() -> ExitCode {
 fn run() -> Result<(), String> {
     let args = parse_args()?;
     let deck = petra_deck::load(&args.deck).map_err(|e| e.to_string())?;
-    if args.ensemble > 1 {
-        return run_ensemble(&args, &deck);
+    if args.viz && !matches!(deck.strategy, petra_deck::ExecutionStrategy::Ctmc) {
+        return Err(
+            "the current batch trajectory format supports only CTMC; discrete strategies fail closed"
+                .to_string(),
+        );
+    }
+    let ensemble = args.ensemble.unwrap_or(deck.n_replicas);
+    if ensemble > 1 {
+        return run_ensemble(&args, &deck, ensemble);
     }
     let mut engine = deck.build_engine(args.seed).map_err(|e| e.to_string())?;
     let steps = args.steps.unwrap_or(deck.steps);
@@ -156,21 +164,25 @@ fn run() -> Result<(), String> {
     };
 
     println!(
-        "deck '{}': {} sites, {} reactions, T = {} K, seed = {}",
+        "deck '{}': {} sites, {} reactions, T = {} K, seed = {}, strategy = {}",
         deck.name,
         engine.lattice.len(),
         engine.reactions.len(),
         deck.temperature,
         args.seed.unwrap_or(deck.seed),
+        deck.strategy.as_str(),
     );
     report(&engine, &mut csv)?;
 
     let mut stopped: Option<Stop> = None;
+    let mut strategy = deck.strategy();
     for i in 1..=steps {
-        match engine.step() {
-            Ok(fired) => {
+        match engine.step_with(&mut strategy) {
+            Ok(outcome) => {
                 if let Some(log) = &mut event_log {
-                    log.record(&fired, &engine).map_err(|e| e.to_string())?;
+                    for fired in &outcome.fired {
+                        log.record(fired, &engine).map_err(|e| e.to_string())?;
+                    }
                 }
             }
             Err(stop) => {
@@ -181,7 +193,9 @@ fn run() -> Result<(), String> {
         if i % report_every == 0 {
             report(&engine, &mut csv)?;
             if args.paranoid {
-                engine.paranoid_check().map_err(|e| format!("paranoid: {e}"))?;
+                engine
+                    .paranoid_check()
+                    .map_err(|e| format!("paranoid: {e}"))?;
             }
         }
     }
@@ -258,33 +272,29 @@ fn write_xyz(
     std::fs::write(path, text).map_err(|e| e.to_string())
 }
 
-fn run_ensemble(args: &Args, deck: &petra_deck::CompiledDeck) -> Result<(), String> {
+fn run_ensemble(args: &Args, deck: &petra_deck::CompiledDeck, ensemble: u64) -> Result<(), String> {
     let steps = args.steps.unwrap_or(deck.steps);
     let base_seed = args.seed.unwrap_or(deck.seed);
 
     std::fs::create_dir_all(&args.out).map_err(|e| e.to_string())?;
     let csv_path = format!("{}/ensemble.csv", args.out);
     let mut csv = std::fs::File::create(&csv_path).map_err(|e| e.to_string())?;
-    writeln!(csv, "seed,steps,time,{}", deck.state_names.join(","))
-        .map_err(|e| e.to_string())?;
+    writeln!(csv, "seed,steps,time,{}", deck.state_names.join(",")).map_err(|e| e.to_string())?;
 
     println!(
-        "deck '{}': ensemble of {} runs, seeds {}..={}, {} steps each",
-        deck.name,
-        args.ensemble,
-        base_seed,
-        base_seed + args.ensemble - 1,
-        steps
+        "deck '{}': ensemble of {} runs, seed policy {:?}, {} steps each",
+        deck.name, ensemble, deck.seed_policy, steps
     );
 
     // Per-state running sums for mean/std over ensemble members.
     let mut sum = vec![0.0f64; deck.n_states];
     let mut sumsq = vec![0.0f64; deck.n_states];
-    for k in 0..args.ensemble {
-        let seed = base_seed + k;
+    for k in 0..ensemble {
+        let seed = petra_deck::replica_seed(base_seed, k, deck.seed_policy);
         let mut engine = deck.build_engine(Some(seed)).expect("engine builds");
+        let mut strategy = deck.strategy();
         for _ in 0..steps {
-            if engine.step().is_err() {
+            if engine.step_with(&mut strategy).is_err() {
                 break;
             }
         }
@@ -304,8 +314,8 @@ fn run_ensemble(args: &Args, deck: &petra_deck::CompiledDeck) -> Result<(), Stri
         }
     }
 
-    let n = args.ensemble as f64;
-    println!("final populations, mean ± std over {} members:", args.ensemble);
+    let n = ensemble as f64;
+    println!("final populations, mean ± std over {} members:", ensemble);
     for (i, name) in deck.state_names.iter().enumerate() {
         let mean = sum[i] / n;
         let var = (sumsq[i] / n - mean * mean).max(0.0);

--- a/petra/crates/petra-cli/tests/strategy_cli.rs
+++ b/petra/crates/petra-cli/tests/strategy_cli.rs
@@ -1,0 +1,50 @@
+use std::path::PathBuf;
+use std::process::Command;
+
+#[test]
+fn cli_dispatches_the_deck_selected_strategy() {
+    let repo = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../..");
+    let deck = repo.join("petra/examples/conformance/conway.toml");
+    let out = std::env::temp_dir().join(format!("petra-cli-strategy-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&out);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_petra"))
+        .arg(deck)
+        .arg("--steps")
+        .arg("4")
+        .arg("--out")
+        .arg(&out)
+        .output()
+        .expect("petra CLI runs");
+    let _ = std::fs::remove_dir_all(&out);
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("strategy = synchronous"), "{stdout}");
+    assert!(stdout.contains("completed 4 steps"), "{stdout}");
+}
+
+#[test]
+fn cli_rejects_batch_trajectory_output_for_discrete_strategies() {
+    let repo = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../..");
+    let deck = repo.join("petra/examples/conformance/conway.toml");
+    let out = std::env::temp_dir().join(format!("petra-cli-viz-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&out);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_petra"))
+        .arg(deck)
+        .arg("--steps")
+        .arg("1")
+        .arg("--viz")
+        .arg("--out")
+        .arg(&out)
+        .output()
+        .expect("petra CLI runs");
+    let _ = std::fs::remove_dir_all(&out);
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("batch trajectory format"), "{stderr}");
+}

--- a/petra/crates/petra-core/src/engine.rs
+++ b/petra/crates/petra-core/src/engine.rs
@@ -7,8 +7,10 @@ use rand_pcg::Pcg64Mcg;
 
 use crate::crystal::KindId;
 use crate::lattice::{Lattice, SiteId};
+use crate::rate::R_KCAL;
 use crate::reaction::{
-    all_matches, first_match, guards_pass, resolve_rate, sites_at_distance, EffectTarget, Reaction,
+    all_matches, first_match, guards_pass, resolve_energy_delta, resolve_rate, sites_at_distance,
+    EffectTarget, Reaction, RuleValue,
 };
 
 /// Fenwick (binary-indexed) tree over per-site total rates: O(log N) point
@@ -159,6 +161,8 @@ pub struct ApplyHandle<'a> {
     kinds: &'a [KindId],
     kind_state_ranges: &'a [(u16, u16)],
     site_events: &'a [Vec<(u16, f64)>],
+    enabled_rules: &'a [Vec<u16>],
+    live_sites: &'a [SiteId],
     tree: &'a RateTree,
     scratch: &'a mut Vec<SiteId>,
     pending: &'a mut Vec<PreparedTransition>,
@@ -173,6 +177,33 @@ impl ApplyHandle<'_> {
     /// Whether any site has an enabled event, including zero-rate events.
     pub fn has_events(&self) -> bool {
         self.site_events.iter().any(|events| !events.is_empty())
+    }
+
+    /// Enabled rules at `site`, in rule-index order, evaluated against the
+    /// immutable pre-step state.
+    pub fn enabled_rules(&self, site: SiteId) -> &[u16] {
+        &self.enabled_rules[site]
+    }
+
+    pub fn energy_delta(&mut self, site: SiteId, reaction: u16) -> f64 {
+        resolve_energy_delta(
+            self.lattice,
+            self.kinds,
+            &self.rules[reaction as usize],
+            site,
+            self.scratch,
+        )
+    }
+
+    pub fn probability(&self, reaction: u16) -> f64 {
+        let RuleValue::Probability(probability) = self.rules[reaction as usize].value else {
+            panic!("probability called for a non-PCA rule")
+        };
+        probability
+    }
+
+    pub fn live_sites(&self) -> &[SiteId] {
+        self.live_sites
     }
 
     /// Select one enabled event using the legacy coupled site/event draw.
@@ -310,6 +341,39 @@ pub trait UpdateStrategy {
 #[derive(Debug, Default)]
 pub struct ExactCtmc;
 
+/// Deterministic, double-buffered cellular automaton. Every rule match reads
+/// the pre-step lattice; the engine commits all selected writes as one batch.
+#[derive(Debug, Default)]
+pub struct SynchronousCA;
+
+/// Asynchronous single-site Metropolis updates. Temperature is Kelvin and
+/// rule energies are canonical kcal/mol, so acceptance uses exp(-ΔE/RT).
+#[derive(Debug)]
+pub struct AsyncMetropolis {
+    temperature: f64,
+}
+
+impl AsyncMetropolis {
+    pub fn new(temperature: f64) -> Self {
+        assert!(temperature.is_finite() && temperature > 0.0);
+        Self { temperature }
+    }
+}
+
+/// Per-site probabilistic cellular automaton with Bernoulli decisions made
+/// against one shared pre-step state and committed as one batch.
+#[derive(Debug, Default)]
+pub struct DiscreteTimePCA;
+
+/// A deck-selected strategy value suitable for library and CLI callers.
+#[derive(Debug)]
+pub enum Strategy {
+    ExactCtmc(ExactCtmc),
+    Synchronous(SynchronousCA),
+    Metropolis(AsyncMetropolis),
+    Pca(DiscreteTimePCA),
+}
+
 pub struct Engine {
     pub lattice: Lattice,
     pub reactions: Vec<Reaction>,
@@ -322,6 +386,10 @@ pub struct Engine {
     temperature: f64,
     /// Cached candidate events per site: (reaction id, resolved rate).
     site_events: Vec<Vec<(u16, f64)>>,
+    /// Center/guard-enabled rules in rule-index order, independent of rate.
+    enabled_rules: Vec<Vec<u16>>,
+    /// Live-site ids in ascending order, fixed for the lifetime of a lattice.
+    live_sites: Vec<SiteId>,
     tree: RateTree,
     /// Global maximum read distance over all reactions: after an event
     /// changes some sites, every site within this graph distance of a
@@ -386,6 +454,12 @@ impl Engine {
             .max()
             .unwrap_or(0);
         let n = lattice.len();
+        let live_sites = lattice
+            .frozen
+            .iter()
+            .enumerate()
+            .filter_map(|(site, &frozen)| (!frozen).then_some(site))
+            .collect();
         let mut engine = Engine {
             lattice,
             reactions,
@@ -394,6 +468,8 @@ impl Engine {
             kind_state_ranges,
             temperature,
             site_events: vec![Vec::new(); n],
+            enabled_rules: vec![Vec::new(); n],
+            live_sites,
             tree: RateTree::new(n),
             max_read,
             time: 0.0,
@@ -413,6 +489,8 @@ impl Engine {
     fn refresh_site(&mut self, s: SiteId) {
         let mut events = std::mem::take(&mut self.site_events[s]);
         events.clear();
+        let mut enabled = std::mem::take(&mut self.enabled_rules[s]);
+        enabled.clear();
         if !self.lattice.frozen[s] {
             let kind = self.kinds[s];
             let state = self.lattice.states[s];
@@ -421,16 +499,19 @@ impl Engine {
                 if rxn.center_states.contains(state)
                     && guards_pass(&self.lattice, &self.kinds, rxn, s, &mut self.scratch)
                 {
-                    let rate = resolve_rate(
-                        &self.lattice,
-                        &self.kinds,
-                        rxn,
-                        s,
-                        self.temperature,
-                        &mut self.scratch,
-                    );
-                    if rate > 0.0 {
-                        events.push((ri, rate));
+                    enabled.push(ri);
+                    if rxn.value == RuleValue::Ctmc {
+                        let rate = resolve_rate(
+                            &self.lattice,
+                            &self.kinds,
+                            rxn,
+                            s,
+                            self.temperature,
+                            &mut self.scratch,
+                        );
+                        if rate > 0.0 {
+                            events.push((ri, rate));
+                        }
                     }
                 }
             }
@@ -438,6 +519,7 @@ impl Engine {
         let total: f64 = events.iter().map(|&(_, r)| r).sum();
         self.tree.set(s, total);
         self.site_events[s] = events;
+        self.enabled_rules[s] = enabled;
     }
 
     /// Advance with an explicitly supplied strategy. The strategy can only
@@ -462,6 +544,8 @@ impl Engine {
                     kinds: &self.kinds,
                     kind_state_ranges: &self.kind_state_ranges,
                     site_events: &self.site_events,
+                    enabled_rules: &self.enabled_rules,
+                    live_sites: &self.live_sites,
                     tree: &self.tree,
                     scratch: &mut self.scratch,
                     pending: &mut pending,
@@ -481,6 +565,24 @@ impl Engine {
         for (fired, transition) in outcome.fired.iter().zip(&pending) {
             debug_assert_eq!(fired.site, transition.site);
             debug_assert_eq!(fired.reaction, transition.reaction);
+        }
+        if pending.len() > 1 {
+            // A batch is evaluated against one pre-step state. Conflicting
+            // writes cannot be made simultaneous by choosing an arbitrary
+            // iteration winner, so fail atomically before mutating anything.
+            let mut writes = vec![None; self.lattice.len()];
+            for transition in &pending {
+                for &(target, state) in &transition.writes {
+                    if writes[target].is_some_and(|prior| prior != state) {
+                        return Err(Stop::EffectFailed {
+                            site: transition.site,
+                            reaction: transition.reaction,
+                            reason: "conflicting simultaneous writes",
+                        });
+                    }
+                    writes[target] = Some(state);
+                }
+            }
         }
         self.commit_transitions(pending);
         self.time += outcome.dt;
@@ -546,7 +648,6 @@ impl Engine {
         for site in dirty {
             self.refresh_site(site);
         }
-
     }
 
     /// The per-site state changes of the most recently applied event:
@@ -621,6 +722,110 @@ impl UpdateStrategy for ExactCtmc {
             }],
             dt,
         })
+    }
+}
+
+impl UpdateStrategy for SynchronousCA {
+    fn step(&mut self, ctx: &mut StepCtx<'_>) -> Result<StepOutcome, Stop> {
+        let mut selected = Vec::new();
+        for site in 0..ctx.lattice.len() {
+            if let Some(&reaction) = ctx.apply.enabled_rules(site).first() {
+                selected.push((site, reaction));
+            }
+        }
+
+        let mut fired = Vec::with_capacity(selected.len());
+        for (site, reaction) in selected {
+            ctx.apply.apply_transition(site, reaction, &mut *ctx.rng)?;
+            fired.push(Fired {
+                step: 0,
+                time: 0.0,
+                site,
+                reaction,
+            });
+        }
+        Ok(StepOutcome { fired, dt: 1.0 })
+    }
+}
+
+impl UpdateStrategy for AsyncMetropolis {
+    fn step(&mut self, ctx: &mut StepCtx<'_>) -> Result<StepOutcome, Stop> {
+        let live_sites = ctx.apply.live_sites();
+        if live_sites.is_empty() {
+            return Err(Stop::NoEvents);
+        }
+        let site_draw = ctx.rng.gen::<f64>();
+        let site =
+            live_sites[((site_draw * live_sites.len() as f64) as usize).min(live_sites.len() - 1)];
+        let enabled = ctx.apply.enabled_rules(site);
+        let dt = 1.0 / live_sites.len() as f64;
+        if enabled.is_empty() {
+            return Ok(StepOutcome {
+                fired: Vec::new(),
+                dt,
+            });
+        }
+
+        let proposal_draw = ctx.rng.gen::<f64>();
+        let reaction =
+            enabled[((proposal_draw * enabled.len() as f64) as usize).min(enabled.len() - 1)];
+        let delta = ctx.apply.energy_delta(site, reaction);
+        let acceptance = (-delta / (R_KCAL * self.temperature)).exp().min(1.0);
+        let acceptance_draw = ctx.rng.gen::<f64>();
+        if acceptance_draw >= acceptance {
+            return Ok(StepOutcome {
+                fired: Vec::new(),
+                dt,
+            });
+        }
+
+        ctx.apply.apply_transition(site, reaction, &mut *ctx.rng)?;
+        Ok(StepOutcome {
+            fired: vec![Fired {
+                step: 0,
+                time: 0.0,
+                site,
+                reaction,
+            }],
+            dt,
+        })
+    }
+}
+
+impl UpdateStrategy for DiscreteTimePCA {
+    fn step(&mut self, ctx: &mut StepCtx<'_>) -> Result<StepOutcome, Stop> {
+        let mut selected = Vec::new();
+        for site in 0..ctx.lattice.len() {
+            for &reaction in ctx.apply.enabled_rules(site) {
+                let draw = ctx.rng.gen::<f64>();
+                if draw < ctx.apply.probability(reaction) {
+                    selected.push((site, reaction));
+                }
+            }
+        }
+
+        let mut fired = Vec::with_capacity(selected.len());
+        for (site, reaction) in selected {
+            ctx.apply.apply_transition(site, reaction, &mut *ctx.rng)?;
+            fired.push(Fired {
+                step: 0,
+                time: 0.0,
+                site,
+                reaction,
+            });
+        }
+        Ok(StepOutcome { fired, dt: 1.0 })
+    }
+}
+
+impl UpdateStrategy for Strategy {
+    fn step(&mut self, ctx: &mut StepCtx<'_>) -> Result<StepOutcome, Stop> {
+        match self {
+            Strategy::ExactCtmc(strategy) => strategy.step(ctx),
+            Strategy::Synchronous(strategy) => strategy.step(ctx),
+            Strategy::Metropolis(strategy) => strategy.step(ctx),
+            Strategy::Pca(strategy) => strategy.step(ctx),
+        }
     }
 }
 

--- a/petra/crates/petra-core/src/lib.rs
+++ b/petra/crates/petra-core/src/lib.rs
@@ -13,7 +13,8 @@ pub mod reaction;
 pub mod state;
 
 pub use engine::{
-    ApplyHandle, Engine, ExactCtmc, Fired, StepCtx, StepOutcome, Stop, UpdateStrategy,
+    ApplyHandle, AsyncMetropolis, DiscreteTimePCA, Engine, ExactCtmc, Fired, StepCtx, StepOutcome,
+    Stop, Strategy, SynchronousCA, UpdateStrategy,
 };
 pub use lattice::{Boundary, Lattice, SiteId};
 pub use state::{StateId, StateSet};

--- a/petra/crates/petra-core/src/reaction.rs
+++ b/petra/crates/petra-core/src/reaction.rs
@@ -150,6 +150,17 @@ pub struct Branch {
     pub effects: Vec<Effect>,
 }
 
+/// Strategy-specific interpretation of a rule's declarative `rate` field.
+/// CTMC keeps its existing [`RateExpr`] in `Reaction::rate`; the other
+/// variants carry only the scalar their strategy consumes.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum RuleValue {
+    Ctmc,
+    Deterministic,
+    Energy(f64),
+    Probability(f64),
+}
+
 /// A fully compiled elementary reaction.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Reaction {
@@ -158,6 +169,7 @@ pub struct Reaction {
     pub center_states: StateSet,
     pub guards: Vec<Guard>,
     pub rate: RateExpr,
+    pub value: RuleValue,
     /// ln of the solution-coupling factor (activities, chemical potentials),
     /// folded once at compile time: k *= exp(ln_thermo).
     pub ln_thermo: f64,
@@ -235,10 +247,9 @@ pub fn count_matches(
     sel: &NeighborSelect,
     scratch: &mut Vec<SiteId>,
 ) -> u32 {
-    if sel.distance == 1 && sel.label.is_some() {
+    if let (1, Some(label)) = (sel.distance, sel.label) {
         // Label filters only make sense on direct bonds; walk the CSR row
         // with its parallel label array.
-        let label = sel.label.unwrap();
         let nbrs = lat.neighbors(center);
         let labels = lat.neighbor_labels(center);
         return nbrs
@@ -264,8 +275,7 @@ pub fn all_matches(
     out: &mut Vec<SiteId>,
 ) {
     out.clear();
-    if sel.distance == 1 && sel.label.is_some() {
-        let label = sel.label.unwrap();
+    if let (1, Some(label)) = (sel.distance, sel.label) {
         let nbrs = lat.neighbors(center);
         let labels = lat.neighbor_labels(center);
         out.extend(
@@ -293,8 +303,7 @@ pub fn first_match(
     sel: &NeighborSelect,
     scratch: &mut Vec<SiteId>,
 ) -> Option<SiteId> {
-    if sel.distance == 1 && sel.label.is_some() {
-        let label = sel.label.unwrap();
+    if let (1, Some(label)) = (sel.distance, sel.label) {
         let nbrs = lat.neighbors(center);
         let labels = lat.neighbor_labels(center);
         return nbrs
@@ -358,6 +367,35 @@ pub fn resolve_rate(
         }
     }
     rxn.rate.base_rate(temperature) * rxn.ln_thermo.exp() * (-extra_ea / rt).exp() * factor
+}
+
+/// Resolve a Metropolis proposal's local energy change. Energy modifiers use
+/// the same deterministic neighbor-count machinery as CTMC barrier modifiers,
+/// but contribute directly to ΔE.
+pub fn resolve_energy_delta(
+    lat: &Lattice,
+    kinds: &[KindId],
+    rxn: &Reaction,
+    center: SiteId,
+    scratch: &mut Vec<SiteId>,
+) -> f64 {
+    let RuleValue::Energy(mut delta) = rxn.value else {
+        panic!("resolve_energy_delta called for a non-Metropolis rule")
+    };
+    for modifier in &rxn.modifiers {
+        let count = count_matches(lat, kinds, center, &modifier.select, scratch);
+        match &modifier.kind {
+            ModifierKind::PerMatch { dea } => delta += dea * count as f64,
+            ModifierKind::ByCount { dea } => {
+                delta += dea[(count as usize).min(dea.len() - 1)];
+            }
+            ModifierKind::When { min, max, dea, .. } if count >= *min && count <= *max => {
+                delta += dea
+            }
+            ModifierKind::When { .. } => {}
+        }
+    }
+    delta
 }
 
 /// Do all guards of `rxn` pass at `center`? (Center kind/state are checked

--- a/petra/crates/petra-deck/src/compile.rs
+++ b/petra/crates/petra-deck/src/compile.rs
@@ -9,7 +9,7 @@ use petra_core::lattice::{Boundary, Lattice};
 use petra_core::rate::{RateExpr, R_KCAL};
 use petra_core::reaction::{
     count_matches, Branch, Effect, EffectOp, EffectTarget, Guard, Modifier, ModifierKind,
-    NeighborSelect, Reaction,
+    NeighborSelect, Reaction, RuleValue,
 };
 use petra_core::state::{StateId, StateSet};
 use petra_core::Engine;
@@ -32,6 +32,7 @@ fn err<T>(msg: impl Into<String>) -> Result<T, CompileError> {
 pub struct CompiledDeck {
     pub name: String,
     pub unit_cell: UnitCell,
+    simple_grid: bool,
     pub kinds_per_template: Vec<KindId>,
     pub kind_names: Vec<String>,
     /// `"Kind.state"`, indexed by `StateId`.
@@ -53,7 +54,29 @@ pub struct CompiledDeck {
     pub boundary: [Boundary; 3],
     pub steps: u64,
     pub seed: u64,
+    pub n_replicas: u64,
+    pub seed_policy: SeedPolicy,
     pub report_every: u64,
+    pub strategy: ExecutionStrategy,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum ExecutionStrategy {
+    Ctmc,
+    Synchronous,
+    Metropolis { temperature: f64 },
+    Pca,
+}
+
+impl ExecutionStrategy {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Ctmc => "ctmc",
+            Self::Synchronous => "synchronous",
+            Self::Metropolis { .. } => "metropolis",
+            Self::Pca => "pca",
+        }
+    }
 }
 
 /// One compiled build-time pass (design doc §3.1 fill rules): sweep all
@@ -92,13 +115,53 @@ pub struct CompiledDefect {
     pub cap: Option<f64>,
 }
 
+fn simplify_grid_adjacency(lattice: &mut Lattice) {
+    let mut offsets = Vec::with_capacity(lattice.len() + 1);
+    let mut adjacency = Vec::new();
+    let mut labels = Vec::new();
+    offsets.push(0);
+    for site in 0..lattice.len() {
+        let start = lattice.adj_off[site] as usize;
+        let end = lattice.adj_off[site + 1] as usize;
+        for index in start..end {
+            let neighbor = lattice.adj[index];
+            if neighbor == site as u32 || adjacency[offsets[site] as usize..].contains(&neighbor) {
+                continue;
+            }
+            adjacency.push(neighbor);
+            labels.push(lattice.adj_label[index]);
+        }
+        offsets.push(adjacency.len() as u32);
+    }
+    lattice.adj_off = offsets;
+    lattice.adj = adjacency;
+    lattice.adj_label = labels;
+}
+
 impl CompiledDeck {
+    /// Construct the update strategy declared by `[execution]`.
+    pub fn strategy(&self) -> petra_core::Strategy {
+        match self.strategy {
+            ExecutionStrategy::Ctmc => petra_core::Strategy::ExactCtmc(petra_core::ExactCtmc),
+            ExecutionStrategy::Synchronous => {
+                petra_core::Strategy::Synchronous(petra_core::SynchronousCA)
+            }
+            ExecutionStrategy::Metropolis { temperature } => {
+                petra_core::Strategy::Metropolis(petra_core::AsyncMetropolis::new(temperature))
+            }
+            ExecutionStrategy::Pca => petra_core::Strategy::Pca(petra_core::DiscreteTimePCA),
+        }
+    }
+
     /// Instantiate the lattice (uniform per-kind fill), run the init
     /// passes, compute defect strain fields, and build the engine.
     pub fn build_engine(&self, seed_override: Option<u64>) -> Result<Engine, CompileError> {
         let seed = seed_override.unwrap_or(self.seed);
         let initial = self.initial_per_template.clone();
         let mut lattice = Lattice::build(&self.unit_cell, self.dims, self.boundary, |t| initial[t]);
+        if self.simple_grid {
+            simplify_grid_adjacency(&mut lattice);
+        }
         let mut kinds: Vec<KindId> = lattice
             .template_index
             .iter()
@@ -363,15 +426,59 @@ fn splitmix64(mut x: u64) -> u64 {
     z ^ (z >> 31)
 }
 
-pub fn compile(deck: &DeckFile) -> Result<CompiledDeck, CompileError> {
-    if deck.structure_kind != StructureKind::Cell {
-        return err(
-            "grid structures parse in schema v2 but compile with B3's conformance strategies",
-        );
+fn compile_boundary(values: &[String]) -> Result<[Boundary; 3], CompileError> {
+    let mut boundary = [Boundary::Periodic; 3];
+    for (axis, value) in values.iter().enumerate() {
+        boundary[axis] = match value.as_str() {
+            "periodic" => Boundary::Periodic,
+            "open" => Boundary::Open,
+            "fixed" => Boundary::Fixed,
+            other => return err(format!("unknown boundary '{other}'")),
+        };
     }
-    if deck.execution.strategy != "ctmc" {
+    Ok(boundary)
+}
+
+fn grid_offsets(family: &str, neighborhood: Option<&str>) -> Vec<[i32; 3]> {
+    match (family, neighborhood) {
+        ("square", Some("von_neumann")) => {
+            vec![[1, 0, 0], [-1, 0, 0], [0, 1, 0], [0, -1, 0]]
+        }
+        ("square", Some("moore")) => (-1..=1)
+            .flat_map(|a| (-1..=1).map(move |b| [a, b, 0]))
+            .filter(|offset| *offset != [0, 0, 0])
+            .collect(),
+        ("hex", None) => vec![
+            [1, 0, 0],
+            [-1, 0, 0],
+            [0, 1, 0],
+            [0, -1, 0],
+            [1, -1, 0],
+            [-1, 1, 0],
+        ],
+        ("cubic", Some("von_neumann")) => vec![
+            [1, 0, 0],
+            [-1, 0, 0],
+            [0, 1, 0],
+            [0, -1, 0],
+            [0, 0, 1],
+            [0, 0, -1],
+        ],
+        ("cubic", Some("moore")) => (-1..=1)
+            .flat_map(|a| (-1..=1).flat_map(move |b| (-1..=1).map(move |c| [a, b, c])))
+            .filter(|offset| *offset != [0, 0, 0])
+            .collect(),
+        _ => unreachable!("grid family and neighborhood validated during deserialization"),
+    }
+}
+
+pub fn compile(deck: &DeckFile) -> Result<CompiledDeck, CompileError> {
+    if !matches!(
+        deck.execution.strategy.as_str(),
+        "ctmc" | "synchronous" | "metropolis" | "pca"
+    ) {
         return err(format!(
-            "strategy '{}' is not implemented in B2 (only 'ctmc' is available)",
+            "strategy '{}' is not implemented",
             deck.execution.strategy
         ));
     }
@@ -457,82 +564,129 @@ pub fn compile(deck: &DeckFile) -> Result<CompiledDeck, CompileError> {
     }
     names.n_states = state_names.len();
 
-    // --- unit cell: geometry, sites, then bonds expanded onto both endpoints ---
-    let params = (
-        deck.cell.a,
-        deck.cell.b,
-        deck.cell.c,
-        deck.cell.alpha,
-        deck.cell.beta,
-        deck.cell.gamma,
-    );
-    let cell =
-        match (deck.cell.matrix, params) {
-            (Some(m), (None, None, None, None, None, None)) => Cell::from_matrix(m),
-            (None, (Some(a), Some(b), Some(c), Some(al), Some(be), Some(ga))) => {
-                Cell::from_params(a, b, c, al, be, ga)
+    // --- topology: explicit cells and grid sugar both lower to one UnitCell ---
+    let (unit_cell, kinds_per_template, initial_per_template, dims, boundary) = match deck
+        .structure_kind
+    {
+        StructureKind::Cell => {
+            let params = (
+                deck.cell.a,
+                deck.cell.b,
+                deck.cell.c,
+                deck.cell.alpha,
+                deck.cell.beta,
+                deck.cell.gamma,
+            );
+            let cell = match (deck.cell.matrix, params) {
+                    (Some(m), (None, None, None, None, None, None)) => Cell::from_matrix(m),
+                    (None, (Some(a), Some(b), Some(c), Some(al), Some(be), Some(ga))) => {
+                        Cell::from_params(a, b, c, al, be, ga)
+                    }
+                    _ => return err(
+                        "cell geometry must be either all of a,b,c,alpha,beta,gamma or a matrix, not a mix",
+                    ),
+                };
+            let mut tsites = Vec::new();
+            let mut kinds_per_template = Vec::new();
+            let mut initial_per_template = Vec::new();
+            for (si, s) in deck.cell.sites.iter().enumerate() {
+                let ki = *names.kind_ids.get(&s.kind).ok_or_else(|| {
+                    CompileError(format!("cell site has unknown kind '{}'", s.kind))
+                })?;
+                kinds_per_template.push(KindId(ki));
+                initial_per_template.push(initial_by_kind[ki as usize]);
+                let frac = match (s.frac, s.cart) {
+                    (Some(f), None) => f,
+                    (None, Some(c)) => cell
+                        .to_fractional(c)
+                        .map_err(|e| CompileError(format!("cell site {si}: {e}")))?,
+                    _ => return err(format!("cell site {si}: exactly one of frac/cart")),
+                };
+                tsites.push(TemplateSite {
+                    kind: KindId(ki),
+                    frac,
+                    bonds: Vec::new(),
+                });
             }
-            _ => return err(
-                "cell geometry must be either all of a,b,c,alpha,beta,gamma or a matrix, not a mix",
-            ),
-        };
-    let mut tsites = Vec::new();
-    let mut kinds_per_template = Vec::new();
-    let mut initial_per_template = Vec::new();
-    for (si, s) in deck.cell.sites.iter().enumerate() {
-        let ki = *names
-            .kind_ids
-            .get(&s.kind)
-            .ok_or_else(|| CompileError(format!("cell site has unknown kind '{}'", s.kind)))?;
-        kinds_per_template.push(KindId(ki));
-        initial_per_template.push(initial_by_kind[ki as usize]);
-        let frac = match (s.frac, s.cart) {
-            (Some(f), None) => f,
-            (None, Some(c)) => cell
-                .to_fractional(c)
-                .map_err(|e| CompileError(format!("cell site {si}: {e}")))?,
-            _ => return err(format!("cell site {si}: exactly one of frac/cart")),
-        };
-        tsites.push(TemplateSite {
-            kind: KindId(ki),
-            frac,
-            bonds: Vec::new(),
-        });
-    }
-    for b in &deck.cell.bonds {
-        if b.i >= tsites.len() || b.j >= tsites.len() {
-            return err(format!("bond ({}, {}) references a missing site", b.i, b.j));
-        }
-        if b.i == b.j && b.dcell == [0, 0, 0] {
-            return err(format!("site {} bonded to itself in the same cell", b.i));
-        }
-        let label = match &b.label {
-            None => NO_LABEL,
-            Some(l) => {
-                let next = names.labels.len() as u16;
-                *names.labels.entry(l.clone()).or_insert(next)
+            for b in &deck.cell.bonds {
+                if b.i >= tsites.len() || b.j >= tsites.len() {
+                    return err(format!("bond ({}, {}) references a missing site", b.i, b.j));
+                }
+                if b.i == b.j && b.dcell == [0, 0, 0] {
+                    return err(format!("site {} bonded to itself in the same cell", b.i));
+                }
+                let label = match &b.label {
+                    None => NO_LABEL,
+                    Some(l) => {
+                        let next = names.labels.len() as u16;
+                        *names.labels.entry(l.clone()).or_insert(next)
+                    }
+                };
+                let fwd = TemplateBond {
+                    to: b.j,
+                    dcell: b.dcell,
+                    label,
+                };
+                let rev = TemplateBond {
+                    to: b.i,
+                    dcell: [-b.dcell[0], -b.dcell[1], -b.dcell[2]],
+                    label,
+                };
+                if !tsites[b.i].bonds.contains(&fwd) {
+                    tsites[b.i].bonds.push(fwd);
+                }
+                if !tsites[b.j].bonds.contains(&rev) {
+                    tsites[b.j].bonds.push(rev);
+                }
             }
-        };
-        let fwd = TemplateBond {
-            to: b.j,
-            dcell: b.dcell,
-            label,
-        };
-        let rev = TemplateBond {
-            to: b.i,
-            dcell: [-b.dcell[0], -b.dcell[1], -b.dcell[2]],
-            label,
-        };
-        if !tsites[b.i].bonds.contains(&fwd) {
-            tsites[b.i].bonds.push(fwd);
+            (
+                UnitCell {
+                    cell,
+                    sites: tsites,
+                },
+                kinds_per_template,
+                initial_per_template,
+                deck.lattice.dims,
+                compile_boundary(&deck.lattice.boundary)?,
+            )
         }
-        if !tsites[b.j].bonds.contains(&rev) {
-            tsites[b.j].bonds.push(rev);
+        StructureKind::Grid => {
+            let grid = deck.grid.as_ref().expect("validated grid structure");
+            let kind = *names.kind_ids.get(&grid.default_kind).ok_or_else(|| {
+                CompileError(format!(
+                    "grid default_kind names unknown kind '{}'",
+                    grid.default_kind
+                ))
+            })?;
+            let mut dims = [1, 1, 1];
+            dims[..grid.dims.len()].copy_from_slice(&grid.dims);
+            let mut boundary_names = vec!["periodic".to_string(); 3];
+            boundary_names[..grid.boundary.len()].clone_from_slice(&grid.boundary);
+
+            let offsets = grid_offsets(&grid.family, grid.neighborhood.as_deref());
+            let bonds = offsets
+                .into_iter()
+                .map(|dcell| TemplateBond {
+                    to: 0,
+                    dcell,
+                    label: NO_LABEL,
+                })
+                .collect();
+            (
+                UnitCell {
+                    cell: Cell::from_params(1.0, 1.0, 1.0, 90.0, 90.0, 90.0),
+                    sites: vec![TemplateSite {
+                        kind: KindId(kind),
+                        frac: [0.0; 3],
+                        bonds,
+                    }],
+                },
+                vec![KindId(kind)],
+                vec![initial_by_kind[kind as usize]],
+                dims,
+                compile_boundary(&boundary_names)?,
+            )
         }
-    }
-    let unit_cell = UnitCell {
-        cell,
-        sites: tsites,
     };
     unit_cell
         .check_reciprocity()
@@ -544,17 +698,6 @@ pub fn compile(deck: &DeckFile) -> Result<CompiledDeck, CompileError> {
         return err("temperature must be positive");
     }
     let rt = R_KCAL * temperature;
-
-    // --- boundary ---
-    let mut boundary = [Boundary::Periodic; 3];
-    for (i, b) in deck.lattice.boundary.iter().enumerate() {
-        boundary[i] = match b.as_str() {
-            "periodic" => Boundary::Periodic,
-            "open" => Boundary::Open,
-            "fixed" => Boundary::Fixed,
-            other => return err(format!("unknown boundary '{other}'")),
-        };
-    }
 
     // --- reactions ---
     let mut reactions = Vec::new();
@@ -580,13 +723,7 @@ pub fn compile(deck: &DeckFile) -> Result<CompiledDeck, CompileError> {
             });
         }
 
-        let rate = compile_rate(
-            r.rate
-                .as_ref()
-                .ok_or_else(|| CompileError(format!("{ctx}: CTMC rule requires rate")))?,
-            eunit,
-            &ctx,
-        )?;
+        let (rate, value) = compile_rate(r.rate.as_ref(), &deck.execution.strategy, eunit, &ctx)?;
 
         // Fold solution coupling into ln_thermo (design doc §4):
         // each consumed species contributes ln(activity) + Δμ/RT.
@@ -663,6 +800,7 @@ pub fn compile(deck: &DeckFile) -> Result<CompiledDeck, CompileError> {
             center_states,
             guards,
             rate,
+            value,
             ln_thermo,
             strain_scale: r.strain.as_ref().map(|s| s.scale).unwrap_or(0.0),
             modifiers,
@@ -723,7 +861,6 @@ pub fn compile(deck: &DeckFile) -> Result<CompiledDeck, CompileError> {
         });
     }
 
-    let dims = deck.lattice.dims;
     if dims.contains(&0) {
         return err("lattice dims must be nonzero");
     }
@@ -834,6 +971,7 @@ pub fn compile(deck: &DeckFile) -> Result<CompiledDeck, CompileError> {
     Ok(CompiledDeck {
         name: deck.deck.name.clone(),
         unit_cell,
+        simple_grid: deck.structure_kind == StructureKind::Grid,
         kinds_per_template,
         kind_names,
         state_names,
@@ -850,7 +988,23 @@ pub fn compile(deck: &DeckFile) -> Result<CompiledDeck, CompileError> {
         boundary,
         steps: deck.execution.stop.steps.unwrap_or(0),
         seed: deck.execution.ensemble.seed,
+        n_replicas: deck.execution.ensemble.n_replicas,
+        seed_policy: deck.execution.ensemble.seed_policy,
         report_every: deck.observables.report_every,
+        strategy: match deck.execution.strategy.as_str() {
+            "ctmc" => ExecutionStrategy::Ctmc,
+            "synchronous" => ExecutionStrategy::Synchronous,
+            "metropolis" => ExecutionStrategy::Metropolis {
+                temperature: deck
+                    .execution
+                    .metropolis
+                    .as_ref()
+                    .and_then(|spec| spec.temperature)
+                    .unwrap_or(temperature),
+            },
+            "pca" => ExecutionStrategy::Pca,
+            _ => unreachable!("strategy checked before compilation"),
+        },
     })
 }
 
@@ -963,27 +1117,56 @@ fn compile_selector(
     })
 }
 
-fn compile_rate(r: &RateSpec, eunit: f64, ctx: &str) -> Result<RateExpr, CompileError> {
-    match (
+fn compile_rate(
+    rate: Option<&RateSpec>,
+    strategy: &str,
+    eunit: f64,
+    ctx: &str,
+) -> Result<(RateExpr, RuleValue), CompileError> {
+    if strategy == "synchronous" {
+        return Ok((RateExpr::Constant { k: 0.0 }, RuleValue::Deterministic));
+    }
+    if strategy == "metropolis" {
+        let delta = rate
+            .and_then(|rate| rate.energy.as_ref())
+            .ok_or_else(|| CompileError(format!("{ctx}: Metropolis rule requires energy.delta")))?
+            .delta
+            * eunit;
+        return Ok((RateExpr::Constant { k: 0.0 }, RuleValue::Energy(delta)));
+    }
+    if strategy == "pca" {
+        let probability = rate
+            .and_then(|rate| rate.probability)
+            .ok_or_else(|| CompileError(format!("{ctx}: PCA rule requires probability")))?;
+        return Ok((
+            RateExpr::Constant { k: 0.0 },
+            RuleValue::Probability(probability),
+        ));
+    }
+    let r = rate.ok_or_else(|| CompileError(format!("{ctx}: CTMC rule requires rate")))?;
+    let rate = match (
         r.constant,
         &r.arrhenius,
         &r.eyring,
         &r.energy,
         r.probability,
     ) {
-        (Some(k), None, None, None, None) => Ok(RateExpr::Constant { k }),
-        (None, Some(a), None, None, None) => Ok(RateExpr::Arrhenius {
+        (Some(k), None, None, None, None) => RateExpr::Constant { k },
+        (None, Some(a), None, None, None) => RateExpr::Arrhenius {
             prefactor: a.prefactor,
             ea: a.ea * eunit,
-        }),
-        (None, None, Some(e), None, None) => Ok(RateExpr::Eyring {
+        },
+        (None, None, Some(e), None, None) => RateExpr::Eyring {
             dh: e.dh * eunit,
             ds: e.ds * eunit,
-        }),
-        _ => err(format!(
-            "{ctx}: CTMC rate needs exactly one of constant/arrhenius/eyring"
-        )),
-    }
+        },
+        _ => {
+            return err(format!(
+                "{ctx}: CTMC rate needs exactly one of constant/arrhenius/eyring"
+            ))
+        }
+    };
+    Ok((rate, RuleValue::Ctmc))
 }
 
 /// Resolve one state name within a specific kind (plain or "Kind."-prefixed).

--- a/petra/crates/petra-deck/src/lib.rs
+++ b/petra/crates/petra-deck/src/lib.rs
@@ -7,7 +7,7 @@ pub mod schema;
 
 use std::path::Path;
 
-pub use compile::{compile, replica_seed, CompileError, CompiledDeck};
+pub use compile::{compile, replica_seed, CompileError, CompiledDeck, ExecutionStrategy};
 pub use schema::{DeckFile, SeedPolicy, StructureKind};
 
 #[derive(Debug, thiserror::Error)]

--- a/petra/crates/petra-deck/src/schema.rs
+++ b/petra/crates/petra-deck/src/schema.rs
@@ -367,6 +367,16 @@ fn validate_v2_surfaces(deck: &DeckV2) -> Result<(), String> {
             .iter()
             .chain(rule.branches.iter().flat_map(|branch| &branch.effects))
             .collect();
+        if deck.execution.strategy == "synchronous"
+            && (rule.branches.len() > 1
+                || effects
+                    .iter()
+                    .any(|effect| effect.select_mode.as_deref() == Some("one")))
+        {
+            return Err(format!(
+                "{ctx}: synchronous rules are draw-free and cannot use weighted branches or select_mode = 'one'"
+            ));
+        }
         let source = rule.center.is_none();
         if source && effects.iter().any(|effect| effect.target != "source") {
             return Err(format!(

--- a/petra/crates/petra-deck/tests/conformance.rs
+++ b/petra/crates/petra-deck/tests/conformance.rs
@@ -1,0 +1,761 @@
+use std::path::PathBuf;
+
+fn conformance_text(name: &str) -> String {
+    std::fs::read_to_string(
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../..")
+            .join("petra/examples/conformance")
+            .join(name),
+    )
+    .unwrap_or_else(|error| panic!("read conformance deck {name}: {error}"))
+}
+
+#[test]
+fn square_grid_compiles_to_periodic_csr_adjacency() {
+    let text = r#"
+[deck]
+name = "grid-compile"
+schema = 2
+
+[structure]
+kind = "grid"
+grid = "square"
+neighborhood = "von_neumann"
+dims = [3, 3]
+boundary = ["periodic", "periodic"]
+default_kind = "site"
+
+[[structure.kinds]]
+name = "site"
+initial = "empty"
+[[structure.kinds.states]]
+name = "empty"
+occupant = "vacant"
+
+[dynamics.thermo]
+temperature = 300.0
+
+[execution]
+strategy = "ctmc"
+[execution.stop]
+steps = 1
+"#;
+    let parsed: petra_deck::DeckFile = toml::from_str(text).expect("grid parses");
+    let deck = petra_deck::compile(&parsed).expect("grid compiles");
+    let engine = deck.build_engine(Some(7)).expect("grid engine builds");
+
+    assert_eq!(engine.lattice.len(), 9);
+    assert_eq!(engine.lattice.dims, [3, 3, 1]);
+    for site in 0..engine.lattice.len() {
+        assert_eq!(engine.lattice.neighbors(site).len(), 4, "site {site}");
+    }
+}
+
+#[test]
+fn tiny_periodic_grids_have_simple_adjacency_without_loops_or_duplicates() {
+    for (dims, neighborhood, expected_degree) in [
+        ("[1, 1]", "von_neumann", 0),
+        ("[2, 2]", "von_neumann", 2),
+        ("[2, 2]", "moore", 3),
+    ] {
+        let text = format!(
+            r#"
+[deck]
+name = "tiny-grid"
+schema = 2
+[structure]
+kind = "grid"
+grid = "square"
+neighborhood = "{neighborhood}"
+dims = {dims}
+boundary = ["periodic", "periodic"]
+default_kind = "site"
+[[structure.kinds]]
+name = "site"
+initial = "empty"
+[[structure.kinds.states]]
+name = "empty"
+occupant = "vacant"
+[dynamics.thermo]
+temperature = 1.0
+[execution]
+strategy = "ctmc"
+"#
+        );
+        let parsed: petra_deck::DeckFile = toml::from_str(&text).expect("tiny grid parses");
+        let deck = petra_deck::compile(&parsed).expect("tiny grid compiles");
+        let engine = deck.build_engine(Some(1)).expect("tiny grid builds");
+        for site in 0..engine.lattice.len() {
+            let neighbors = engine.lattice.neighbors(site);
+            assert_eq!(neighbors.len(), expected_degree, "{dims} {neighborhood}");
+            assert!(!neighbors.contains(&(site as u32)), "self-loop at {site}");
+            let mut unique = neighbors.to_vec();
+            unique.sort_unstable();
+            unique.dedup();
+            assert_eq!(unique.len(), neighbors.len(), "duplicate at {site}");
+        }
+    }
+}
+
+#[test]
+fn every_rfc_grid_family_compiles_with_expected_coordination() {
+    for (family, neighborhood, dims, expected_degree) in [
+        ("square", Some("moore"), "[4, 4]", 8),
+        ("hex", None, "[4, 4]", 6),
+        ("cubic", Some("von_neumann"), "[4, 4, 4]", 6),
+        ("cubic", Some("moore"), "[4, 4, 4]", 26),
+    ] {
+        let neighborhood = neighborhood
+            .map(|name| format!("neighborhood = \"{name}\""))
+            .unwrap_or_default();
+        let boundary = if family == "cubic" {
+            "[\"periodic\", \"periodic\", \"periodic\"]"
+        } else {
+            "[\"periodic\", \"periodic\"]"
+        };
+        let text = format!(
+            r#"
+[deck]
+name = "{family}-grid"
+schema = 2
+[structure]
+kind = "grid"
+grid = "{family}"
+{neighborhood}
+dims = {dims}
+boundary = {boundary}
+default_kind = "site"
+[[structure.kinds]]
+name = "site"
+initial = "empty"
+[[structure.kinds.states]]
+name = "empty"
+occupant = "vacant"
+[dynamics.thermo]
+temperature = 1.0
+[execution]
+strategy = "ctmc"
+"#
+        );
+        let parsed: petra_deck::DeckFile = toml::from_str(&text).expect("grid parses");
+        let deck = petra_deck::compile(&parsed).expect("grid compiles");
+        let engine = deck.build_engine(Some(1)).expect("grid builds");
+        assert!(
+            (0..engine.lattice.len())
+                .all(|site| { engine.lattice.neighbors(site).len() == expected_degree }),
+            "{family} {neighborhood}"
+        );
+    }
+}
+
+const CONWAY: &str = r#"
+[deck]
+name = "conway-glider"
+schema = 2
+
+[structure]
+kind = "grid"
+grid = "square"
+neighborhood = "moore"
+dims = [8, 8]
+boundary = ["periodic", "periodic"]
+default_kind = "cell"
+
+[[structure.species]]
+name = "life"
+[[structure.kinds]]
+name = "cell"
+initial = "dead"
+[[structure.kinds.states]]
+name = "dead"
+occupant = "vacant"
+[[structure.kinds.states]]
+name = "alive"
+occupant = "life"
+
+[[structure.init]]
+name = "glider"
+center = { kind = "cell", state = ["dead"] }
+sites = [[1, 0, 0, 0], [2, 1, 0, 0], [0, 2, 0, 0], [1, 2, 0, 0], [2, 2, 0, 0]]
+set = "alive"
+
+[dynamics.thermo]
+temperature = 1.0
+
+[[dynamics.rules]]
+name = "underpopulation"
+center = { kind = "cell", state = ["alive"] }
+guards = [{ distance = 1, kind = "cell", state = ["alive"], max = 1 }]
+[[dynamics.rules.effects]]
+target = "center"
+set = "dead"
+
+[[dynamics.rules]]
+name = "overpopulation"
+center = { kind = "cell", state = ["alive"] }
+guards = [{ distance = 1, kind = "cell", state = ["alive"], min = 4 }]
+[[dynamics.rules.effects]]
+target = "center"
+set = "dead"
+
+[[dynamics.rules]]
+name = "birth"
+center = { kind = "cell", state = ["dead"] }
+guards = [{ distance = 1, kind = "cell", state = ["alive"], min = 3, max = 3 }]
+[[dynamics.rules.effects]]
+target = "center"
+set = "alive"
+
+[execution]
+strategy = "synchronous"
+[execution.stop]
+steps = 8
+"#;
+
+fn alive_sites(
+    deck: &petra_deck::CompiledDeck,
+    engine: &petra_core::Engine,
+) -> Vec<(usize, usize)> {
+    let alive = deck
+        .state_names
+        .iter()
+        .position(|name| name == "cell.alive")
+        .expect("alive state") as u16;
+    engine
+        .lattice
+        .states
+        .iter()
+        .enumerate()
+        .filter(|(_, state)| state.0 == alive)
+        .map(|(site, _)| {
+            let ([x, y, _], _) = engine.lattice.coords(site);
+            (x, y)
+        })
+        .collect()
+}
+
+#[test]
+fn conway_glider_has_period_four_and_displacement_one_one() {
+    let text = conformance_text("conway.toml");
+    let parsed: petra_deck::DeckFile = toml::from_str(&text).expect("Conway deck parses");
+    let deck = petra_deck::compile(&parsed).expect("Conway deck compiles");
+    let mut engine = deck.build_engine(Some(42)).expect("engine builds");
+    let initial = alive_sites(&deck, &engine);
+    let mut strategy = deck.strategy();
+
+    for _ in 0..4 {
+        engine
+            .step_with(&mut strategy)
+            .expect("synchronous step succeeds");
+    }
+
+    let shifted: Vec<_> = initial.iter().map(|&(x, y)| (x + 1, y + 1)).collect();
+    assert_eq!(alive_sites(&deck, &engine), shifted);
+    assert_eq!(engine.time.to_bits(), 4.0f64.to_bits());
+}
+
+#[test]
+fn conway_blinker_has_period_two_and_block_is_still() {
+    let text = conformance_text("conway.toml");
+    let build_pattern = |cells: &[(usize, usize)], seed| {
+        let mut parsed: petra_deck::DeckFile = toml::from_str(&text).expect("Conway deck parses");
+        parsed.init[0].sites = Some(cells.iter().map(|&(x, y)| [x, y, 0, 0]).collect());
+        let deck = petra_deck::compile(&parsed).expect("Conway pattern compiles");
+        let engine = deck.build_engine(Some(seed)).expect("pattern engine");
+        (deck, engine)
+    };
+
+    let horizontal = vec![(1, 2), (2, 2), (3, 2)];
+    let vertical = vec![(2, 1), (2, 2), (2, 3)];
+    let (blinker_deck, mut blinker) = build_pattern(&horizontal, 1);
+    let mut strategy = blinker_deck.strategy();
+    blinker
+        .step_with(&mut strategy)
+        .expect("first blinker step");
+    assert_eq!(alive_sites(&blinker_deck, &blinker), vertical);
+    blinker
+        .step_with(&mut strategy)
+        .expect("second blinker step");
+    assert_eq!(alive_sites(&blinker_deck, &blinker), horizontal);
+
+    let block_pattern = vec![(1, 1), (1, 2), (2, 1), (2, 2)];
+    let (block_deck, mut block) = build_pattern(&block_pattern, 2);
+    let mut strategy = block_deck.strategy();
+    block.step_with(&mut strategy).expect("block step");
+    assert_eq!(alive_sites(&block_deck, &block), block_pattern);
+}
+
+#[test]
+fn synchronous_rules_reject_hidden_random_draws() {
+    let random_branches = CONWAY.replace(
+        "[[dynamics.rules.effects]]\ntarget = \"center\"\nset = \"dead\"",
+        "[[dynamics.rules.branches]]\nweight = 1.0\n[[dynamics.rules.branches.effects]]\ntarget = \"center\"\nset = \"dead\"\n[[dynamics.rules.branches]]\nweight = 1.0\n[[dynamics.rules.branches.effects]]\ntarget = \"center\"\nset = \"dead\"",
+    );
+    let error = toml::from_str::<petra_deck::DeckFile>(&random_branches)
+        .expect_err("synchronous CA must remain draw-free");
+    assert!(error.to_string().contains("draw-free"), "{error}");
+}
+
+const ISING: &str = r#"
+[deck]
+name = "ising-2d"
+schema = 2
+units = "kcal/mol"
+
+[structure]
+kind = "grid"
+grid = "square"
+neighborhood = "von_neumann"
+dims = [8, 8]
+boundary = ["periodic", "periodic"]
+default_kind = "spin"
+
+[[structure.species]]
+name = "plus"
+[[structure.species]]
+name = "minus"
+[[structure.kinds]]
+name = "spin"
+initial = "up"
+[[structure.kinds.states]]
+name = "up"
+occupant = "plus"
+[[structure.kinds.states]]
+name = "down"
+occupant = "minus"
+
+[[structure.init]]
+name = "random-spins"
+center = { kind = "spin", state = ["up"] }
+probability = 0.5
+set = "down"
+
+[dynamics.thermo]
+temperature = 2.269185314
+
+[[dynamics.rules]]
+name = "up-to-down"
+center = { kind = "spin", state = ["up"] }
+rate = { energy = { delta = -0.015896 } }
+[[dynamics.rules.modifiers]]
+select = { distance = 1, kind = "spin", state = ["up"] }
+per_match = { dea = 0.007948 }
+[[dynamics.rules.effects]]
+target = "center"
+set = "down"
+
+[[dynamics.rules]]
+name = "down-to-up"
+center = { kind = "spin", state = ["down"] }
+rate = { energy = { delta = -0.015896 } }
+[[dynamics.rules.modifiers]]
+select = { distance = 1, kind = "spin", state = ["down"] }
+per_match = { dea = 0.007948 }
+[[dynamics.rules.effects]]
+target = "center"
+set = "up"
+
+[execution]
+strategy = "metropolis"
+[execution.metropolis]
+temperature = 2.269185314
+[execution.stop]
+steps = 100000
+[execution.ensemble]
+seed = 42
+n_replicas = 10
+seed_policy = "hash"
+"#;
+
+fn binder_cumulant(size: usize, temperature: f64) -> f64 {
+    let text = conformance_text("ising.toml");
+    let mut parsed: petra_deck::DeckFile = toml::from_str(&text).expect("Ising deck parses");
+    parsed.grid.as_mut().expect("grid").dims = vec![size, size];
+    parsed
+        .execution
+        .metropolis
+        .as_mut()
+        .expect("Metropolis parameters")
+        .temperature = Some(temperature);
+    let deck = petra_deck::compile(&parsed).expect("Ising deck compiles");
+    let up = deck
+        .state_names
+        .iter()
+        .position(|name| name == "spin.up")
+        .expect("up state") as u16;
+    let sites = size * size;
+    let mut m2 = 0.0;
+    let mut m4 = 0.0;
+    let mut samples = 0.0;
+
+    for replica in 0..deck.n_replicas {
+        let seed = petra_deck::replica_seed(deck.seed, replica, deck.seed_policy);
+        let mut engine = deck.build_engine(Some(seed)).expect("engine builds");
+        let mut strategy = deck.strategy();
+        for _ in 0..300 * sites {
+            engine.step_with(&mut strategy).expect("burn-in step");
+        }
+        for _ in 0..500 {
+            for _ in 0..sites {
+                engine.step_with(&mut strategy).expect("sample sweep");
+            }
+            let n_up = engine
+                .lattice
+                .states
+                .iter()
+                .filter(|state| state.0 == up)
+                .count() as f64;
+            let magnetization = (2.0 * n_up - sites as f64) / sites as f64;
+            let square = magnetization * magnetization;
+            m2 += square;
+            m4 += square * square;
+            samples += 1.0;
+        }
+    }
+    let mean2 = m2 / samples;
+    let mean4 = m4 / samples;
+    1.0 - mean4 / (3.0 * mean2 * mean2)
+}
+
+#[test]
+fn ising_binder_crossing_is_near_onsager_critical_temperature() {
+    const ONSAGER_TC: f64 = 2.269_185_314_213_022;
+    const TOLERANCE: f64 = 0.25;
+    let temperatures = [2.0, ONSAGER_TC, 2.6];
+    let differences: Vec<_> = temperatures
+        .iter()
+        .map(|&temperature| binder_cumulant(8, temperature) - binder_cumulant(12, temperature))
+        .collect();
+    let crossing = temperatures
+        .windows(2)
+        .zip(differences.windows(2))
+        .find_map(|(temperature, difference)| {
+            if difference[0] * difference[1] <= 0.0 {
+                Some(
+                    temperature[0]
+                        - difference[0] * (temperature[1] - temperature[0])
+                            / (difference[1] - difference[0]),
+                )
+            } else {
+                None
+            }
+        })
+        .unwrap_or_else(|| panic!("Binder curves did not cross: differences={differences:?}"));
+    eprintln!(
+        "Binder crossing={crossing:.6}, Onsager={ONSAGER_TC:.6}, differences={differences:?}"
+    );
+
+    assert!(
+        (crossing - ONSAGER_TC).abs() <= TOLERANCE,
+        "crossing {crossing:.6}, Onsager {ONSAGER_TC:.6}, tolerance {TOLERANCE}, differences={differences:?}"
+    );
+}
+
+const SIR: &str = r#"
+[deck]
+name = "sir-pca"
+schema = 2
+
+[structure]
+kind = "grid"
+grid = "square"
+neighborhood = "von_neumann"
+dims = [32, 32]
+boundary = ["periodic", "periodic"]
+default_kind = "person"
+
+[[structure.species]]
+name = "host"
+[[structure.kinds]]
+name = "person"
+initial = "susceptible"
+[[structure.kinds.states]]
+name = "susceptible"
+occupant = "host"
+[[structure.kinds.states]]
+name = "infected"
+occupant = "host"
+[[structure.kinds.states]]
+name = "recovered"
+occupant = "host"
+
+[[structure.init]]
+name = "seed-infections"
+center = { kind = "person", state = ["susceptible"] }
+probability = 0.01
+set = "infected"
+
+[dynamics.thermo]
+temperature = 1.0
+
+[[dynamics.rules]]
+name = "infection"
+center = { kind = "person", state = ["susceptible"] }
+guards = [{ distance = 1, kind = "person", state = ["infected"], min = 1 }]
+rate = { probability = 0.05 }
+[[dynamics.rules.effects]]
+target = "center"
+set = "infected"
+
+[[dynamics.rules]]
+name = "recovery"
+center = { kind = "person", state = ["infected"] }
+rate = { probability = 0.2 }
+[[dynamics.rules.effects]]
+target = "center"
+set = "recovered"
+
+[execution]
+strategy = "pca"
+[execution.pca]
+[execution.stop]
+steps = 100
+[execution.ensemble]
+seed = 42
+n_replicas = 128
+seed_policy = "hash"
+"#;
+
+fn sir_one_step_growth(r0: f64) -> f64 {
+    const GAMMA: f64 = 0.2;
+    const COORDINATION: f64 = 4.0;
+    let text = conformance_text("sir.toml");
+    let mut parsed: petra_deck::DeckFile = toml::from_str(&text).expect("SIR deck parses");
+    parsed.reactions[0]
+        .rate
+        .as_mut()
+        .expect("infection rate")
+        .probability = Some(r0 * GAMMA / COORDINATION);
+    let deck = petra_deck::compile(&parsed).expect("SIR deck compiles");
+    let infected = deck
+        .state_names
+        .iter()
+        .position(|name| name == "person.infected")
+        .expect("infected state") as u16;
+    let mut before = 0u64;
+    let mut after = 0u64;
+    for replica in 0..deck.n_replicas {
+        let seed = petra_deck::replica_seed(deck.seed, replica, deck.seed_policy);
+        let mut engine = deck.build_engine(Some(seed)).expect("engine builds");
+        before += engine
+            .lattice
+            .states
+            .iter()
+            .filter(|state| state.0 == infected)
+            .count() as u64;
+        let mut strategy = deck.strategy();
+        engine.step_with(&mut strategy).expect("PCA step");
+        after += engine
+            .lattice
+            .states
+            .iter()
+            .filter(|state| state.0 == infected)
+            .count() as u64;
+    }
+    after as f64 / before as f64
+}
+
+#[test]
+fn sir_growth_threshold_matches_mean_field_r0_one() {
+    const TOLERANCE: f64 = 0.15;
+    let low_r0 = 0.5;
+    let high_r0 = 1.5;
+    let low_growth = sir_one_step_growth(low_r0);
+    let high_growth = sir_one_step_growth(high_r0);
+    assert!(low_growth < 1.0, "R0={low_r0}: growth={low_growth}");
+    assert!(high_growth > 1.0, "R0={high_r0}: growth={high_growth}");
+    let threshold = low_r0 + (1.0 - low_growth) * (high_r0 - low_r0) / (high_growth - low_growth);
+    eprintln!(
+        "SIR threshold={threshold:.6}, growth({low_r0})={low_growth:.6}, growth({high_r0})={high_growth:.6}"
+    );
+    assert!(
+        (threshold - 1.0).abs() <= TOLERANCE,
+        "estimated R0 threshold {threshold:.6}, tolerance {TOLERANCE}; growth({low_r0})={low_growth:.6}, growth({high_r0})={high_growth:.6}"
+    );
+}
+
+fn sir_outbreak_probability(r0: f64) -> f64 {
+    const GAMMA: f64 = 0.2;
+    const COORDINATION: f64 = 4.0;
+
+    let text = conformance_text("sir.toml");
+    let mut parsed: petra_deck::DeckFile = toml::from_str(&text).expect("SIR deck parses");
+    parsed.reactions[0]
+        .rate
+        .as_mut()
+        .expect("infection rate")
+        .probability = Some(r0 * GAMMA / COORDINATION);
+    let steps = parsed.execution.stop.steps.expect("SIR stop steps");
+    let deck = petra_deck::compile(&parsed).expect("SIR deck compiles");
+    let infected = deck
+        .state_names
+        .iter()
+        .position(|name| name == "person.infected")
+        .expect("infected state") as u16;
+    let recovered = deck
+        .state_names
+        .iter()
+        .position(|name| name == "person.recovered")
+        .expect("recovered state") as u16;
+    let outbreak_size = engine_outbreak_size(deck.dims[0] * deck.dims[1]);
+    let outbreaks = (0..deck.n_replicas)
+        .filter(|&replica| {
+            let seed = petra_deck::replica_seed(deck.seed, replica, deck.seed_policy);
+            let mut engine = deck.build_engine(Some(seed)).expect("engine builds");
+            let mut strategy = deck.strategy();
+            for _ in 0..steps {
+                engine.step_with(&mut strategy).expect("PCA step");
+            }
+            engine
+                .lattice
+                .states
+                .iter()
+                .filter(|state| state.0 == infected || state.0 == recovered)
+                .count()
+                >= outbreak_size
+        })
+        .count();
+    outbreaks as f64 / deck.n_replicas as f64
+}
+
+fn engine_outbreak_size(site_count: usize) -> usize {
+    // A macroscopic outbreak must reach at least 10% of the finite lattice;
+    // the seeded 1% initial prevalence cannot satisfy this by itself.
+    site_count.div_ceil(10)
+}
+
+#[test]
+fn sir_outbreak_probability_changes_across_mean_field_threshold() {
+    let below = sir_outbreak_probability(0.5);
+    let above = sir_outbreak_probability(2.0);
+    eprintln!("SIR outbreak P(R0=0.5)={below:.6}, P(R0=2.0)={above:.6}");
+    assert!(below <= 0.05, "subcritical outbreak probability {below}");
+    assert!(above >= 0.40, "supercritical outbreak probability {above}");
+}
+
+#[test]
+fn shipped_decks_compile_to_the_models_exercised_by_the_analytic_gates() {
+    for (name, expected) in [
+        ("conway.toml", CONWAY),
+        ("ising.toml", ISING),
+        ("sir.toml", SIR),
+    ] {
+        let actual_text = conformance_text(name);
+        let actual: petra_deck::DeckFile =
+            toml::from_str(&actual_text).unwrap_or_else(|error| panic!("{name} parses: {error}"));
+        let expected: petra_deck::DeckFile =
+            toml::from_str(expected).unwrap_or_else(|error| panic!("{name} gate parses: {error}"));
+        let actual =
+            petra_deck::compile(&actual).unwrap_or_else(|error| panic!("{name} compiles: {error}"));
+        let expected = petra_deck::compile(&expected)
+            .unwrap_or_else(|error| panic!("{name} gate compiles: {error}"));
+        assert_eq!(actual.state_names, expected.state_names, "{name} states");
+        assert_eq!(actual.dims, expected.dims, "{name} dimensions");
+        assert_eq!(actual.boundary, expected.boundary, "{name} boundary");
+        assert_eq!(actual.init_passes, expected.init_passes, "{name} init");
+        assert_eq!(actual.reactions, expected.reactions, "{name} rules");
+        assert_eq!(actual.strategy, expected.strategy, "{name} strategy");
+    }
+}
+
+fn trajectory_fingerprint(name: &str, seed: u64, steps: usize) -> u64 {
+    fn mix(hash: &mut u64, value: u64) {
+        for byte in value.to_le_bytes() {
+            *hash ^= u64::from(byte);
+            *hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+        }
+    }
+
+    let text = conformance_text(name);
+    let parsed: petra_deck::DeckFile = toml::from_str(&text).expect("deck parses");
+    let deck = petra_deck::compile(&parsed).expect("deck compiles");
+    let mut engine = deck.build_engine(Some(seed)).expect("engine builds");
+    let mut strategy = deck.strategy();
+    let mut hash = 0xcbf2_9ce4_8422_2325;
+    for _ in 0..steps {
+        let outcome = engine.step_with(&mut strategy).expect("strategy step");
+        mix(&mut hash, outcome.dt.to_bits());
+        mix(&mut hash, outcome.fired.len() as u64);
+        for fired in outcome.fired {
+            mix(&mut hash, fired.step);
+            mix(&mut hash, fired.time.to_bits());
+            mix(&mut hash, fired.site as u64);
+            mix(&mut hash, u64::from(fired.reaction));
+        }
+    }
+    for state in &engine.lattice.states {
+        mix(&mut hash, u64::from(state.0));
+    }
+    hash
+}
+
+#[test]
+fn pca_rejects_conflicting_simultaneous_writes() {
+    let text = r#"
+[deck]
+name = "pca-conflict"
+schema = 2
+[structure]
+kind = "grid"
+grid = "square"
+neighborhood = "von_neumann"
+dims = [1, 1]
+boundary = ["periodic", "periodic"]
+default_kind = "site"
+[[structure.species]]
+name = "x"
+[[structure.kinds]]
+name = "site"
+initial = "a"
+[[structure.kinds.states]]
+name = "a"
+occupant = "x"
+[[structure.kinds.states]]
+name = "b"
+occupant = "x"
+[[structure.kinds.states]]
+name = "c"
+occupant = "x"
+[dynamics.thermo]
+temperature = 1.0
+[[dynamics.rules]]
+name = "a-to-b"
+center = { kind = "site", state = ["a"] }
+rate = { probability = 1.0 }
+[[dynamics.rules.effects]]
+target = "center"
+set = "b"
+[[dynamics.rules]]
+name = "a-to-c"
+center = { kind = "site", state = ["a"] }
+rate = { probability = 1.0 }
+[[dynamics.rules.effects]]
+target = "center"
+set = "c"
+[execution]
+strategy = "pca"
+"#;
+    let parsed: petra_deck::DeckFile = toml::from_str(text).expect("conflict deck parses");
+    let deck = petra_deck::compile(&parsed).expect("conflict deck compiles");
+    let mut engine = deck.build_engine(Some(4)).expect("conflict engine");
+    let mut strategy = deck.strategy();
+    let error = engine
+        .step_with(&mut strategy)
+        .expect_err("different simultaneous writes must fail closed");
+    assert!(
+        matches!(error, petra_core::Stop::EffectFailed { reason, .. } if reason == "conflicting simultaneous writes")
+    );
+    assert_eq!(engine.lattice.states[0].0, 0, "failure is atomic");
+}
+
+#[test]
+fn stochastic_strategy_draw_order_is_pinned() {
+    assert_eq!(
+        trajectory_fingerprint("ising.toml", 42, 64),
+        2_331_448_806_470_377_247
+    );
+    assert_eq!(
+        trajectory_fingerprint("sir.toml", 42, 8),
+        7_104_091_214_398_920_014
+    );
+}

--- a/petra/crates/petra-deck/tests/kaolinite_golden.rs
+++ b/petra/crates/petra-deck/tests/kaolinite_golden.rs
@@ -18,7 +18,9 @@ use kaolinite::build::LatticeParams;
 use kaolinite::{create_lattice, find_pairs, populate_solid, terminate_lattice};
 
 fn repo_path(rel: &str) -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../..").join(rel)
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../..")
+        .join(rel)
 }
 
 /// Petra "Kind.state" name → legacy 3-digit code.
@@ -29,8 +31,18 @@ fn code_table() -> HashMap<String, i32> {
         }
     }
     let mut m = HashMap::new();
-    add(&mut m, "Al", &["empty", "l0", "l1", "l2", "l3", "l4", "l5", "l6"], 100);
-    add(&mut m, "Si", &["empty", "oh0", "oh1", "oh2", "oh3", "oh4"], 200);
+    add(
+        &mut m,
+        "Al",
+        &["empty", "l0", "l1", "l2", "l3", "l4", "l5", "l6"],
+        100,
+    );
+    add(
+        &mut m,
+        "Si",
+        &["empty", "oh0", "oh1", "oh2", "oh3", "oh4"],
+        200,
+    );
     add(&mut m, "Oss", &["empty", "br", "hy", "si1"], 300);
     add(
         &mut m,
@@ -91,9 +103,7 @@ fn kaolinite_build_matches_kmc_rs_site_by_site() {
             continue;
         }
         if lat.frozen[i] {
-            mismatches.push(format!(
-                "site {i}: petra frozen but legacy state {legacy}"
-            ));
+            mismatches.push(format!("site {i}: petra frozen but legacy state {legacy}"));
             continue;
         }
         let p = petra_code(i);
@@ -148,9 +158,7 @@ fn kaolinite_dynamics_runs_and_conserves_sites() {
         let counts = engine.state_counts(deck.n_states);
         deck.kind_state_ranges
             .iter()
-            .map(|&(start, n)| {
-                (start..start + n).map(|s| counts[s as usize]).sum::<u64>()
-            })
+            .map(|&(start, n)| (start..start + n).map(|s| counts[s as usize]).sum::<u64>())
             .collect()
     };
     assert_eq!(count_by_kind(&engine), kind_totals);
@@ -163,7 +171,9 @@ fn kaolinite_dynamics_runs_and_conserves_sites() {
         assert!(fired.time > last_time, "time must increase (step {i})");
         last_time = fired.time;
         if i % 1000 == 999 {
-            engine.paranoid_check().expect("incremental tables consistent");
+            engine
+                .paranoid_check()
+                .expect("incremental tables consistent");
             assert_eq!(count_by_kind(&engine), kind_totals, "site conservation");
         }
     }

--- a/petra/crates/petra-deck/tests/kaolinite_multilayer.rs
+++ b/petra/crates/petra-deck/tests/kaolinite_multilayer.rs
@@ -23,7 +23,9 @@ const E_HB: f64 = 5.0; // kcal/mol, the deck's placeholder (CALC-001)
 const T: f64 = 8000.0;
 
 fn repo_path(rel: &str) -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../..").join(rel)
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../..")
+        .join(rel)
 }
 
 fn load_multilayer() -> petra_deck::CompiledDeck {
@@ -45,7 +47,10 @@ fn state_id(deck: &petra_deck::CompiledDeck, name: &str) -> StateId {
     )
 }
 
-fn kinds_of(deck: &petra_deck::CompiledDeck, lat: &petra_core::lattice::Lattice) -> Vec<petra_core::crystal::KindId> {
+fn kinds_of(
+    deck: &petra_deck::CompiledDeck,
+    lat: &petra_core::lattice::Lattice,
+) -> Vec<petra_core::crystal::KindId> {
     lat.template_index
         .iter()
         .map(|&t| deck.kinds_per_template[t as usize])
@@ -71,7 +76,12 @@ fn interlayer_bond_topology_matches_geometry() {
     // its bond at the b = 2 fixed face: 20 × 2 × 3 = 120. Times 2 for the
     // two CSR directions.
     let count: usize = (0..lat.len())
-        .map(|s| lat.neighbor_labels(s).iter().filter(|&&l| l == hbond).count())
+        .map(|s| {
+            lat.neighbor_labels(s)
+                .iter()
+                .filter(|&&l| l == hbond)
+                .count()
+        })
         .sum();
     assert_eq!(count, 2 * (900 + 120), "hbond adjacency entries");
 
@@ -105,10 +115,7 @@ fn every_layer_initializes_identically_to_the_single_sheet() {
                 for c in 0..4 {
                     let ml_i = site(a, b, c, t);
                     let ml_name = &ml_deck.state_names[ml.lattice.states[ml_i].0 as usize];
-                    assert_eq!(
-                        ml_name, ss_name,
-                        "state at (a={a}, b={b}, c={c}, t={t})"
-                    );
+                    assert_eq!(ml_name, ss_name, "state at (a={a}, b={b}, c={c}, t={t})");
                     // Frozen flags agree except the one documented case:
                     // donor 24's hbond crosses the fixed b-face, so pos 24
                     // in the extreme b-row freezes in the multilayer.
@@ -274,7 +281,9 @@ fn multilayer_dynamics_runs_and_conserves_sites() {
         assert!(fired.time > last_time, "time must increase (step {i})");
         last_time = fired.time;
         if i % 1000 == 999 {
-            engine.paranoid_check().expect("incremental tables consistent");
+            engine
+                .paranoid_check()
+                .expect("incremental tables consistent");
             assert_eq!(count_by_kind(&engine), kind_totals, "site conservation");
         }
     }

--- a/petra/crates/petra-deck/tests/kossel_smoke.rs
+++ b/petra/crates/petra-deck/tests/kossel_smoke.rs
@@ -16,7 +16,11 @@ fn kossel_deck_compiles_with_expected_shape() {
     assert_eq!(deck.kind_names, ["M_site"]);
     assert_eq!(deck.state_names, ["M_site.occupied", "M_site.empty"]);
     assert_eq!(deck.reactions.len(), 2);
-    assert_eq!(deck.unit_cell.sites[0].bonds.len(), 6, "expanded to ±a ±b ±c");
+    assert_eq!(
+        deck.unit_cell.sites[0].bonds.len(),
+        6,
+        "expanded to ±a ±b ±c"
+    );
     // Attach folds mu = -2 into ln_thermo: ln(1) + (-2)/RT.
     let attach = deck
         .reactions
@@ -91,7 +95,11 @@ fn same_seed_reproduces_same_seed_diverges_different() {
     let (t1, c1) = run(11);
     let (t2, c2) = run(11);
     let (t3, c3) = run(12);
-    assert_eq!(t1.to_bits(), t2.to_bits(), "same seed → identical trajectory");
+    assert_eq!(
+        t1.to_bits(),
+        t2.to_bits(),
+        "same seed → identical trajectory"
+    );
     assert_eq!(c1, c2);
     assert!(
         t1.to_bits() != t3.to_bits() || c1 != c3,

--- a/petra/crates/petra-deck/tests/schema_v2.rs
+++ b/petra/crates/petra-deck/tests/schema_v2.rs
@@ -269,7 +269,7 @@ fn unknown_schema_version_is_rejected() {
 }
 
 #[test]
-fn non_ctmc_strategy_is_rejected_in_b2() {
+fn metropolis_strategy_compiles_in_b3() {
     let text = V2
         .replace("strategy = \"ctmc\"", "strategy = \"metropolis\"")
         .replace(
@@ -277,11 +277,11 @@ fn non_ctmc_strategy_is_rejected_in_b2() {
             "rate = { energy = { delta = 2.0 } }",
         );
     let parsed: petra_deck::DeckFile = toml::from_str(&text).expect("future strategy parses");
-    let error = petra_deck::compile(&parsed).expect_err("B2 implements only CTMC");
-    assert!(
-        error.to_string().contains("not implemented in B2"),
-        "{error}"
-    );
+    let deck = petra_deck::compile(&parsed).expect("Metropolis compiles");
+    assert!(matches!(
+        deck.strategy,
+        petra_deck::ExecutionStrategy::Metropolis { temperature: 300.0 }
+    ));
 }
 
 #[test]
@@ -321,19 +321,19 @@ fn execution_parameter_blocks_validate_at_parse_time() {
 }
 
 #[test]
-fn future_strategy_rate_surfaces_parse_then_compile_reject() {
+fn b3_strategy_rate_surfaces_parse_and_compile() {
     let synchronous = V2
         .replace("strategy = \"ctmc\"", "strategy = \"synchronous\"")
         .replace("rate = { constant = 2.0 }\n", "truth = \"and\"\n");
     let parsed: petra_deck::DeckFile =
         toml::from_str(&synchronous).expect("synchronous truth surface parses");
-    assert!(petra_deck::compile(&parsed).is_err());
+    assert!(petra_deck::compile(&parsed).is_ok());
 
     let pca = V2
         .replace("strategy = \"ctmc\"", "strategy = \"pca\"")
         .replace("rate = { constant = 2.0 }", "rate = { probability = 0.25 }");
     let parsed: petra_deck::DeckFile = toml::from_str(&pca).expect("PCA probability parses");
-    assert!(petra_deck::compile(&parsed).is_err());
+    assert!(petra_deck::compile(&parsed).is_ok());
 }
 
 #[test]
@@ -357,7 +357,7 @@ fn rfc_surfaces_fail_closed_at_parse_time() {
 }
 
 #[test]
-fn grid_v2_parses_but_waits_for_b3_compilation() {
+fn grid_v2_compiles_to_the_shared_lattice_representation() {
     let text = r#"
 [deck]
 name = "grid-parse"
@@ -385,8 +385,14 @@ steps = 10
 "#;
     let parsed: petra_deck::DeckFile = toml::from_str(text).expect("grid schema parses");
     assert_eq!(parsed.structure_kind, StructureKind::Grid);
-    let error = petra_deck::compile(&parsed).expect_err("grid compile is B3");
-    assert!(error.to_string().contains("B3"), "{error}");
+    let deck = petra_deck::compile(&parsed).expect("grid compiles in B3");
+    let engine = deck.build_engine(Some(1)).expect("grid lattice builds");
+    assert_eq!(engine.lattice.dims, [8, 8, 1]);
+    assert!(engine
+        .lattice
+        .adj_off
+        .windows(2)
+        .all(|offset| offset[1] - offset[0] == 8));
 }
 
 struct PublicSeamCtmc;

--- a/petra/crates/petra-deck/tests/strain_gates.rs
+++ b/petra/crates/petra-deck/tests/strain_gates.rs
@@ -6,9 +6,9 @@
 
 use std::path::PathBuf;
 
-use petra_core::Lattice;
 use petra_core::rate::R_KCAL;
 use petra_core::reaction::resolve_rate;
+use petra_core::Lattice;
 
 /// 9×9 single-site sheet, screw along c with a bare prefactor: u = 16/r²,
 /// clamp at 2 Å. Cell is a 3 Å cube so cartesian = 3 × cell coords.
@@ -111,7 +111,11 @@ fn strain_field_matches_hand_formula_with_clamp_and_min_image() {
     assert!((u(3, 5) - 16.0 / 180.0).abs() < 1e-12);
     // Minimum image: site (8,1) is 7 cells = 21 Å away directly, but only
     // 2 cells = 6 Å through the periodic wrap → u = 16/36.
-    assert!((u(8, 1) - 16.0 / 36.0).abs() < 1e-12, "min-image: {}", u(8, 1));
+    assert!(
+        (u(8, 1) - 16.0 / 36.0).abs() < 1e-12,
+        "min-image: {}",
+        u(8, 1)
+    );
 
     // Superposition sanity: exactly one defect, all sites strained > 0.
     assert!(lat.strain.iter().all(|&v| v > 0.0));

--- a/petra/crates/petra-io/src/events.rs
+++ b/petra/crates/petra-io/src/events.rs
@@ -24,7 +24,12 @@ pub struct EventLogWriter<W: Write> {
 
 impl<W: Write> EventLogWriter<W> {
     /// Write the header line and return the writer.
-    pub fn new(mut out: W, deck: &CompiledDeck, seed: u64, n_sites: usize) -> std::io::Result<Self> {
+    pub fn new(
+        mut out: W,
+        deck: &CompiledDeck,
+        seed: u64,
+        n_sites: usize,
+    ) -> std::io::Result<Self> {
         let state_types: Vec<String> = deck
             .state_occupants
             .iter()
@@ -45,11 +50,7 @@ impl<W: Write> EventLogWriter<W> {
 
     /// Append the event the engine just applied (call after each
     /// successful `step`, before the next one).
-    pub fn record(
-        &mut self,
-        fired: &petra_core::Fired,
-        engine: &Engine,
-    ) -> std::io::Result<()> {
+    pub fn record(&mut self, fired: &petra_core::Fired, engine: &Engine) -> std::io::Result<()> {
         // Hand-formatted compact row — [step, time, rxn, [[site,old,new],..]]
         // — to keep 10^5-event logs cheap to write and parse.
         let mut line = format!("[{},{:.9e},{}", fired.step, fired.time, fired.reaction);
@@ -134,7 +135,7 @@ seed = 1
     /// Run the mini deck to exhaustion, log it, and verify the log replays
     /// forward to the final state and backward to the initial state.
     #[test]
-    fn log_replays_forward_and_backward()  {
+    fn log_replays_forward_and_backward() {
         let parsed: petra_deck::DeckFile = toml::from_str(MINI).unwrap();
         let deck = petra_deck::compile(&parsed).unwrap();
         let mut engine = deck.build_engine(Some(3)).unwrap();
@@ -158,8 +159,7 @@ seed = 1
         let mut replay = initial.clone();
         let mut events = Vec::new();
         for line in lines {
-            let row: (u64, f64, u16, Vec<(usize, u16, u16)>) =
-                serde_json::from_str(line).unwrap();
+            let row: (u64, f64, u16, Vec<(usize, u16, u16)>) = serde_json::from_str(line).unwrap();
             for &(site, old, new) in &row.3 {
                 assert_eq!(replay[site], old, "forward replay consistency");
                 replay[site] = new;

--- a/petra/crates/petra-io/src/pgif.rs
+++ b/petra/crates/petra-io/src/pgif.rs
@@ -220,10 +220,8 @@ seed = 1
         assert_eq!(doc["nodes"]["count"], 4);
         // 4-ring: 4 undirected edges, each emitted once; the 0-3 bond wraps.
         assert_eq!(doc["edges"]["count"], 4);
-        let seam: Vec<bool> = serde_json::from_value(
-            doc["edges"]["columns"]["seam"]["data"].clone(),
-        )
-        .unwrap();
+        let seam: Vec<bool> =
+            serde_json::from_value(doc["edges"]["columns"]["seam"]["data"].clone()).unwrap();
         assert_eq!(seam.iter().filter(|&&s| s).count(), 1, "one wrap edge");
 
         let dict: Vec<String> =

--- a/petra/crates/petra-wasm/src/lib.rs
+++ b/petra/crates/petra-wasm/src/lib.rs
@@ -31,6 +31,11 @@ impl WasmSim {
         let parsed: petra_deck::DeckFile =
             toml::from_str(deck_toml).map_err(|e| JsError::new(&format!("deck parse: {e}")))?;
         let deck = petra_deck::compile(&parsed).map_err(|e| JsError::new(&e.to_string()))?;
+        if !matches!(deck.strategy, petra_deck::ExecutionStrategy::Ctmc) {
+            return Err(JsError::new(
+                "the WASM batch trajectory format currently supports only CTMC",
+            ));
+        }
         let seed_override = if seed >= 0.0 { Some(seed as u64) } else { None };
         let engine = deck
             .build_engine(seed_override)
@@ -51,9 +56,17 @@ impl WasmSim {
     pub fn header_json(&self) -> String {
         let mut buf = Vec::new();
         // The header writer needs a seed for the record; report the deck's.
-        petra_io::EventLogWriter::new(&mut buf, &self.deck, self.deck.seed, self.engine.lattice.len())
-            .expect("writing to a Vec cannot fail");
-        String::from_utf8(buf).expect("header is UTF-8").trim_end().to_string()
+        petra_io::EventLogWriter::new(
+            &mut buf,
+            &self.deck,
+            self.deck.seed,
+            self.engine.lattice.len(),
+        )
+        .expect("writing to a Vec cannot fail");
+        String::from_utf8(buf)
+            .expect("header is UTF-8")
+            .trim_end()
+            .to_string()
     }
 
     /// Run up to `n` events, returning them as a JSON array of §6a rows:

--- a/petra/examples/conformance/conway.toml
+++ b/petra/examples/conformance/conway.toml
@@ -1,0 +1,78 @@
+# Conway's Game of Life conformance deck.
+# CI gate: a glider repeats after four synchronous steps translated by (1, 1).
+[deck]
+name = "conway-glider"
+schema = 2
+
+[structure]
+kind = "grid"
+grid = "square"
+neighborhood = "moore"
+dims = [8, 8]
+boundary = ["periodic", "periodic"]
+default_kind = "cell"
+
+[[structure.species]]
+name = "life"
+
+[[structure.kinds]]
+name = "cell"
+initial = "dead"
+
+[[structure.kinds.states]]
+name = "dead"
+occupant = "vacant"
+
+[[structure.kinds.states]]
+name = "alive"
+occupant = "life"
+
+[[structure.init]]
+name = "glider"
+center = { kind = "cell", state = ["dead"] }
+sites = [[1, 0, 0, 0], [2, 1, 0, 0], [0, 2, 0, 0], [1, 2, 0, 0], [2, 2, 0, 0]]
+set = "alive"
+
+[dynamics.thermo]
+temperature = 1.0
+
+[[dynamics.rules]]
+name = "underpopulation"
+center = { kind = "cell", state = ["alive"] }
+guards = [{ distance = 1, kind = "cell", state = ["alive"], max = 1 }]
+
+[[dynamics.rules.effects]]
+target = "center"
+set = "dead"
+
+[[dynamics.rules]]
+name = "overpopulation"
+center = { kind = "cell", state = ["alive"] }
+guards = [{ distance = 1, kind = "cell", state = ["alive"], min = 4 }]
+
+[[dynamics.rules.effects]]
+target = "center"
+set = "dead"
+
+[[dynamics.rules]]
+name = "birth"
+center = { kind = "cell", state = ["dead"] }
+guards = [{ distance = 1, kind = "cell", state = ["alive"], min = 3, max = 3 }]
+
+[[dynamics.rules.effects]]
+target = "center"
+set = "alive"
+
+[execution]
+strategy = "synchronous"
+
+[execution.stop]
+steps = 8
+
+[execution.ensemble]
+seed = 42
+n_replicas = 1
+seed_policy = "increment"
+
+[observables]
+report_every = 1

--- a/petra/examples/conformance/ising.toml
+++ b/petra/examples/conformance/ising.toml
@@ -1,0 +1,87 @@
+# Two-dimensional nearest-neighbor Ising conformance deck.
+# J is one gas constant (R = 0.001987 kcal mol^-1 K^-1), making the
+# dimensionless Onsager critical temperature numerically 2.269185314 K.
+# CI estimates the L=8/L=12 Binder-cumulant crossing within ±0.25.
+[deck]
+name = "ising-2d"
+schema = 2
+units = "kcal/mol"
+
+[structure]
+kind = "grid"
+grid = "square"
+neighborhood = "von_neumann"
+dims = [8, 8]
+boundary = ["periodic", "periodic"]
+default_kind = "spin"
+
+[[structure.species]]
+name = "plus"
+
+[[structure.species]]
+name = "minus"
+
+[[structure.kinds]]
+name = "spin"
+initial = "up"
+
+[[structure.kinds.states]]
+name = "up"
+occupant = "plus"
+
+[[structure.kinds.states]]
+name = "down"
+occupant = "minus"
+
+[[structure.init]]
+name = "random-spins"
+center = { kind = "spin", state = ["up"] }
+probability = 0.5
+set = "down"
+
+[dynamics.thermo]
+temperature = 2.269185314
+
+# For a square lattice, ΔE = -8J + 4J*n_same for a proposed spin flip.
+[[dynamics.rules]]
+name = "up-to-down"
+center = { kind = "spin", state = ["up"] }
+rate = { energy = { delta = -0.015896 } }
+
+[[dynamics.rules.modifiers]]
+select = { distance = 1, kind = "spin", state = ["up"] }
+per_match = { dea = 0.007948 }
+
+[[dynamics.rules.effects]]
+target = "center"
+set = "down"
+
+[[dynamics.rules]]
+name = "down-to-up"
+center = { kind = "spin", state = ["down"] }
+rate = { energy = { delta = -0.015896 } }
+
+[[dynamics.rules.modifiers]]
+select = { distance = 1, kind = "spin", state = ["down"] }
+per_match = { dea = 0.007948 }
+
+[[dynamics.rules.effects]]
+target = "center"
+set = "up"
+
+[execution]
+strategy = "metropolis"
+
+[execution.metropolis]
+temperature = 2.269185314
+
+[execution.stop]
+steps = 100000
+
+[execution.ensemble]
+seed = 42
+n_replicas = 10
+seed_policy = "hash"
+
+[observables]
+report_every = 1000

--- a/petra/examples/conformance/sir.toml
+++ b/petra/examples/conformance/sir.toml
@@ -1,0 +1,78 @@
+# Discrete-time SIR conformance deck on a square lattice.
+# gamma=0.2 and per-contact infection probability beta/z=0.05 at R0=1,
+# with z=4. CI brackets the one-step growth threshold within ±0.15 of
+# the mean-field prediction R0=beta/gamma=1.
+[deck]
+name = "sir-pca"
+schema = 2
+
+[structure]
+kind = "grid"
+grid = "square"
+neighborhood = "von_neumann"
+dims = [32, 32]
+boundary = ["periodic", "periodic"]
+default_kind = "person"
+
+[[structure.species]]
+name = "host"
+
+[[structure.kinds]]
+name = "person"
+initial = "susceptible"
+
+[[structure.kinds.states]]
+name = "susceptible"
+occupant = "host"
+
+[[structure.kinds.states]]
+name = "infected"
+occupant = "host"
+
+[[structure.kinds.states]]
+name = "recovered"
+occupant = "host"
+
+[[structure.init]]
+name = "seed-infections"
+center = { kind = "person", state = ["susceptible"] }
+probability = 0.01
+set = "infected"
+
+[dynamics.thermo]
+temperature = 1.0
+
+[[dynamics.rules]]
+name = "infection"
+center = { kind = "person", state = ["susceptible"] }
+guards = [{ distance = 1, kind = "person", state = ["infected"], min = 1 }]
+rate = { probability = 0.05 }
+
+[[dynamics.rules.effects]]
+target = "center"
+set = "infected"
+
+[[dynamics.rules]]
+name = "recovery"
+center = { kind = "person", state = ["infected"] }
+rate = { probability = 0.2 }
+
+[[dynamics.rules.effects]]
+target = "center"
+set = "recovered"
+
+[execution]
+strategy = "pca"
+
+[execution.pca]
+
+[execution.stop]
+steps = 100
+
+[execution.ensemble]
+seed = 42
+n_replicas = 128
+seed_policy = "hash"
+
+[observables]
+report_every = 1


### PR DESCRIPTION
## Summary
- compile schema-v2 square/hex/cubic grids and dispatch synchronous CA, asynchronous Metropolis, and discrete-time PCA
- ship Conway, Ising, and SIR conformance decks with deterministic analytic CI gates
- preserve ExactCtmc bitwise parity while hardening batch conflicts, tiny periodic grids, and deck-declared ensemble seeds
- close B3 bookkeeping and unblock C2/D3 on the Omnibus board

## Verification
- cargo test -j 16 --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- cargo fmt --all -- --check
- cargo build -j 16 --workspace
- git diff --check

## Scientific receipts
- Ising Binder crossing: 2.273230 vs Onsager 2.269185
- SIR growth threshold: R0=1.017094 vs mean-field 1.0
- Conway glider: period 4, displacement (1,1); blinker and block gates green

## Summary by Sourcery

Enable schema-v2 grid simulations across multiple update strategies with validated Conway, Ising, and SIR conformance gates while preserving CTMC compatibility.

New Features:
- Add schema-v2 support for square, hexagonal, and cubic grids with synchronous CA, asynchronous Metropolis, and discrete-time PCA execution strategies.
- Provide Conway, Ising, and SIR conformance decks with deterministic analytical CI gates.

Bug Fixes:
- Preserve ExactCtmc bitwise parity while preventing conflicting simultaneous writes and invalid discrete-strategy trajectory output.
- Handle tiny periodic grids without self-loops or duplicate adjacency and honor deck-declared ensemble seed policies.

Enhancements:
- Dispatch strategies selected by decks through the Petra CLI and core engine while retaining CTMC trajectory support.

Documentation:
- Mark B3 conformance work complete and unblock dependent C2 and D3 program cards.

Tests:
- Add conformance coverage for grid topology, strategy dispatch, Conway behavior, Ising criticality, SIR thresholds, deterministic draw order, and atomic batch conflicts.