### PR TITLE
fix(petra): make synchronous rule priority explicit

### DIFF
--- a/petra/crates/petra-core/src/engine.rs
+++ b/petra/crates/petra-core/src/engine.rs
@@ -342,7 +342,9 @@ pub trait UpdateStrategy {
 pub struct ExactCtmc;
 
 /// Deterministic, double-buffered cellular automaton. Every rule match reads
-/// the pre-step lattice; the engine commits all selected writes as one batch.
+/// the pre-step lattice; at most one rule fires per site, with the first
+/// enabled rule in rule-index (deck declaration) order taking priority. The
+/// engine commits all selected writes as one batch.
 #[derive(Debug, Default)]
 pub struct SynchronousCA;
 
@@ -729,6 +731,8 @@ impl UpdateStrategy for SynchronousCA {
     fn step(&mut self, ctx: &mut StepCtx<'_>) -> Result<StepOutcome, Stop> {
         let mut selected = Vec::new();
         for site in 0..ctx.lattice.len() {
+            // Same-site conflicts are intentionally draw-free: the first
+            // enabled rule in deck declaration order wins (RFC-001 §3).
             if let Some(&reaction) = ctx.apply.enabled_rules(site).first() {
                 selected.push((site, reaction));
             }

--- a/petra/crates/petra-deck/src/schema.rs
+++ b/petra/crates/petra-deck/src/schema.rs
@@ -65,7 +65,13 @@ pub struct CtmcSpec {}
 
 #[derive(Debug, Default, Deserialize)]
 #[serde(deny_unknown_fields)]
-pub struct SynchronousSpec {}
+/// Synchronous CA parameters. When multiple rules are enabled at one site,
+/// the first rule in deck declaration order wins (RFC-001 §3).
+pub struct SynchronousSpec {
+    /// Must be `first_match`: synchronous updates are deterministic and fire
+    /// at most one rule per site, prioritized by deck declaration order.
+    pub conflict_resolution: String,
+}
 
 #[derive(Debug, Default, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -527,6 +533,19 @@ fn validate_execution(execution: &ExecutionSpec) -> Result<(), String> {
     match execution.strategy.as_str() {
         "ctmc" | "synchronous" | "metropolis" | "pca" => {}
         other => return Err(format!("unknown execution strategy '{other}'")),
+    }
+    if execution.strategy == "synchronous"
+        && execution
+            .synchronous
+            .as_ref()
+            .map(|spec| spec.conflict_resolution.as_str())
+            != Some("first_match")
+    {
+        return Err(
+            "[execution.synchronous] conflict_resolution = 'first_match' is required; \
+             when multiple rules match one site, the first rule in definition order wins"
+                .to_string(),
+        );
     }
     if let Some(temperature) = execution
         .metropolis

--- a/petra/crates/petra-deck/tests/conformance.rs
+++ b/petra/crates/petra-deck/tests/conformance.rs
@@ -208,6 +208,8 @@ set = "alive"
 
 [execution]
 strategy = "synchronous"
+[execution.synchronous]
+conflict_resolution = "first_match"
 [execution.stop]
 steps = 8
 "#;
@@ -294,6 +296,22 @@ fn synchronous_rules_reject_hidden_random_draws() {
     let error = toml::from_str::<petra_deck::DeckFile>(&random_branches)
         .expect_err("synchronous CA must remain draw-free");
     assert!(error.to_string().contains("draw-free"), "{error}");
+}
+
+#[test]
+fn synchronous_strategy_requires_explicit_first_match_conflict_resolution() {
+    let implicit = CONWAY.replace(
+        "[execution.synchronous]\nconflict_resolution = \"first_match\"\n",
+        "",
+    );
+    let error = toml::from_str::<petra_deck::DeckFile>(&implicit)
+        .expect_err("synchronous CA rule priority must be explicit");
+    assert!(
+        error
+            .to_string()
+            .contains("conflict_resolution = 'first_match'"),
+        "{error}"
+    );
 }
 
 const ISING: &str = r#"

--- a/petra/crates/petra-deck/tests/schema_v2.rs
+++ b/petra/crates/petra-deck/tests/schema_v2.rs
@@ -288,7 +288,7 @@ fn metropolis_strategy_compiles_in_b3() {
 fn every_rfc_strategy_parameter_block_parses() {
     let text = V2.replace(
         "[execution.stop]",
-        "[execution.ctmc]\n[execution.synchronous]\n[execution.metropolis]\ntemperature = 310.0\n[execution.pca]\n[execution.stop]",
+        "[execution.ctmc]\n[execution.synchronous]\nconflict_resolution = \"first_match\"\n[execution.metropolis]\ntemperature = 310.0\n[execution.pca]\n[execution.stop]",
     );
     let parsed: petra_deck::DeckFile = toml::from_str(&text).expect("all blocks parse");
     assert!(parsed.execution.ctmc.is_some());
@@ -324,7 +324,11 @@ fn execution_parameter_blocks_validate_at_parse_time() {
 fn b3_strategy_rate_surfaces_parse_and_compile() {
     let synchronous = V2
         .replace("strategy = \"ctmc\"", "strategy = \"synchronous\"")
-        .replace("rate = { constant = 2.0 }\n", "truth = \"and\"\n");
+        .replace("rate = { constant = 2.0 }\n", "truth = \"and\"\n")
+        .replace(
+            "[execution.stop]",
+            "[execution.synchronous]\nconflict_resolution = \"first_match\"\n[execution.stop]",
+        );
     let parsed: petra_deck::DeckFile =
         toml::from_str(&synchronous).expect("synchronous truth surface parses");
     assert!(petra_deck::compile(&parsed).is_ok());

--- a/petra/docs/RFC-001-DECK-V2.md
+++ b/petra/docs/RFC-001-DECK-V2.md
@@ -276,6 +276,7 @@ strategy = "ctmc" | "synchronous" | "metropolis" | "pca"
 # strategy parameters (per-strategy; see §3)
 [execution.ctmc]        # nothing required — defaults are the current engine
 [execution.synchronous]
+conflict_resolution = "first_match" # required: first rule in definition order wins per site
 [execution.metropolis]
 temperature = 298.15   # defaults to [dynamics.thermo].temperature
 [execution.pca]

--- a/petra/examples/conformance/conway.toml
+++ b/petra/examples/conformance/conway.toml
@@ -66,6 +66,9 @@ set = "alive"
 [execution]
 strategy = "synchronous"
 
+[execution.synchronous]
+conflict_resolution = "first_match"
+
 [execution.stop]
 steps = 8
 


### PR DESCRIPTION
## Summary
- require `conflict_resolution = "first_match"` for synchronous CA decks
- document that deck declaration order defines same-site rule priority
- add schema/conformance coverage and update the Conway deck

Follow-up to #60 after Sourcery flagged the implicit first-enabled-rule behavior.

## Verification
- `cargo test -j 16 --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo build -j 16 --workspace`
- `git diff --check`

## Summary by Sourcery

Make synchronous cellular automata rule priority explicit and deterministic by requiring first-match conflict resolution.

Bug Fixes:
- Require synchronous cellular automata decks to explicitly declare `conflict_resolution = "first_match"`.

Enhancements:
- Clarify and enforce deck declaration order as the priority for same-site synchronous rules.

Documentation:
- Document the required synchronous conflict-resolution setting and declaration-order priority.

Tests:
- Add schema and conformance coverage for explicit synchronous rule priority.

Chores:
- Update the Conway conformance deck with the required synchronous configuration.